### PR TITLE
Mockを使ったAPIのテストコード実装例を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ dist
 # environment variables file
 .envrc
 .env
+
+# webpack output
+.webpack

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/node": "^15.0.1",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
-    "axios-mock-server": "^0.19.1",
+    "axios-mock-adapter": "^1.19.0",
     "eslint": "^7.25.0",
     "eslint-config-prettier": "^8.3.0",
     "jest": "^26.6.3",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "@middy/core": "^1.5.2",
     "@middy/http-json-body-parser": "^1.5.2",
     "ajv": "^8.2.0",
+    "axios": "^0.21.1",
+    "extensible-custom-error": "^0.0.7",
     "source-map-support": "^0.5.19"
   },
   "devDependencies": {
@@ -31,6 +33,7 @@
     "@types/node": "^15.0.1",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
+    "axios-mock-server": "^0.19.1",
     "eslint": "^7.25.0",
     "eslint-config-prettier": "^8.3.0",
     "jest": "^26.6.3",

--- a/serverless.ts
+++ b/serverless.ts
@@ -1,7 +1,5 @@
 import type { AWS } from '@serverless/typescript';
-
-import hello from '@functions/hello';
-import helloWithPath from '@functions/helloWithPath';
+import {hello, helloWithPath, addressSearch} from '@functions/index';
 
 const serverlessConfiguration: AWS = {
   service: 'serverless-node-api',
@@ -29,7 +27,7 @@ const serverlessConfiguration: AWS = {
     lambdaHashingVersion: '20201221',
   },
   // import the function via paths
-  functions: { hello, helloWithPath },
+  functions: { hello, helloWithPath, addressSearch },
 };
 
 module.exports = serverlessConfiguration;

--- a/src/api/domain/types/address.ts
+++ b/src/api/domain/types/address.ts
@@ -1,0 +1,5 @@
+export type Address = {
+  postalCode: string;
+  region: string;
+  locality: string;
+};

--- a/src/api/repositories/errors/FetchAddressByPostalCodeError.ts
+++ b/src/api/repositories/errors/FetchAddressByPostalCodeError.ts
@@ -1,0 +1,10 @@
+import ExtensibleCustomError from 'extensible-custom-error';
+
+export class FetchAddressByPostalCodeError extends ExtensibleCustomError {}
+
+export const FetchAddressByPostalCodeErrorMessage = {
+  addressDoseNotFoundError: 'AddressDoseNotFoundError',
+  unexpectedError: 'UnexpectedError',
+} as const;
+
+export type FetchAddressByPostalCodeErrorMessage = typeof FetchAddressByPostalCodeErrorMessage[keyof typeof FetchAddressByPostalCodeErrorMessage];

--- a/src/api/repositories/implements/axios/address.ts
+++ b/src/api/repositories/implements/axios/address.ts
@@ -1,0 +1,64 @@
+import axios from 'axios';
+import { Address } from '../../../domain/types/address';
+import { FetchAddressByPostalCode } from '../../interfaces/address';
+import {
+  FetchAddressByPostalCodeError,
+  FetchAddressByPostalCodeErrorMessage,
+} from '../../errors/FetchAddressByPostalCodeError';
+
+// Mockに置き換えられるように export する
+export const httpClient = axios.create({ timeout: 5000 });
+
+// http://zipcloud.ibsnet.co.jp/doc/api の結果
+type ExternalAddressSearchApiSuccessResponse = {
+  message: string | null;
+  results:
+    | {
+        address1: string;
+        address2: string;
+        address3: string;
+        kana1: string;
+        kana2: string;
+        kana3: string;
+        prefcode: string;
+        zipcode: string;
+      }[]
+    | null;
+  status: number;
+};
+
+export const fetchAddressByPostalCode: FetchAddressByPostalCode = async (
+  postalCode: string,
+): Promise<Address> => {
+  try {
+    const params = {
+      zipcode: postalCode,
+    };
+
+    const apiResponse = await httpClient.get<ExternalAddressSearchApiSuccessResponse>(
+      'https://zipcloud.ibsnet.co.jp/api/search',
+      { params },
+    );
+
+    if (apiResponse.data.message !== null || !apiResponse.data.results) {
+      return Promise.reject(
+        new FetchAddressByPostalCodeError(
+          FetchAddressByPostalCodeErrorMessage.addressDoseNotFoundError,
+        ),
+      );
+    }
+
+    return {
+      postalCode: postalCode,
+      region: apiResponse.data.results[0].address1,
+      locality: apiResponse.data.results[0].address2,
+    };
+  } catch (error) {
+    return Promise.reject(
+      new FetchAddressByPostalCodeError(
+        FetchAddressByPostalCodeErrorMessage.addressDoseNotFoundError,
+        error,
+      ),
+    );
+  }
+};

--- a/src/api/repositories/interfaces/address.ts
+++ b/src/api/repositories/interfaces/address.ts
@@ -1,0 +1,3 @@
+import { Address } from '../../domain/types/address';
+
+export type FetchAddressByPostalCode = (postalCode: string) => Promise<Address>;

--- a/src/api/utils/assertNever.ts
+++ b/src/api/utils/assertNever.ts
@@ -1,0 +1,8 @@
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/ban-ts-comment */
+// @ts-ignore
+const assertNever = (x: never): never => {
+  throw new Error('Unexpected value. Should have been never.');
+};
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/ban-ts-comment */
+
+export default assertNever;

--- a/src/api/v1/__tests__/addressSearch.spec.ts
+++ b/src/api/v1/__tests__/addressSearch.spec.ts
@@ -1,0 +1,54 @@
+import addressSearch from '../addressSearch';
+
+describe('addressSearch', () => {
+  it('should return a address', () => {
+    const request = {
+      postalCode: '1620062',
+    };
+
+    const expected = {
+      statusCode: 200,
+      body: {
+        postalCode: '1620062',
+        region: '東京',
+        locality: '市谷加賀町',
+      },
+    };
+
+    expect(addressSearch(request)).toStrictEqual(expected);
+  });
+
+  it('should return a NotAllowedPostalCode Error', () => {
+    const request = {
+      postalCode: '1000000',
+    };
+
+    const expected = {
+      statusCode: 400,
+      body: {
+        code: 'NotAllowedPostalCode',
+        message: 'not allowed to search by that postalCode',
+      },
+    };
+
+    expect(addressSearch(request)).toStrictEqual(expected);
+  });
+
+  it('should return a validation error', () => {
+    const request = {
+      postalCode: '12345678',
+    };
+
+    const expected = {
+      statusCode: 422,
+      body: {
+        message: `Unprocessable Entity`,
+        validationErrors: [
+          { key: 'postalCode', reason: 'must NOT have more than 7 characters' },
+        ],
+      },
+    };
+
+    expect(addressSearch(request)).toStrictEqual(expected);
+  });
+});

--- a/src/api/v1/__tests__/addressSearch.spec.ts
+++ b/src/api/v1/__tests__/addressSearch.spec.ts
@@ -69,6 +69,34 @@ describe('addressSearch', () => {
     expect(actual).toStrictEqual(expected);
   });
 
+  it('should return a NotFoundAddress Error', async () => {
+    const mockResponse = {
+      message: null,
+      results: null,
+      status: 200,
+    };
+
+    axiosMock
+      .onGet('https://zipcloud.ibsnet.co.jp/api/search')
+      .reply(200, mockResponse);
+
+    const request = {
+      postalCode: '1620000',
+    };
+
+    const expected = {
+      statusCode: 404,
+      body: {
+        code: 'NotFoundAddress',
+        message: 'address is not found',
+      },
+    };
+
+    const actual = await addressSearch(request, fetchAddressByPostalCode);
+
+    expect(actual).toStrictEqual(expected);
+  });
+
   it('should return a validation error', async () => {
     const request = {
       postalCode: '12345678',

--- a/src/api/v1/__tests__/addressSearch.spec.ts
+++ b/src/api/v1/__tests__/addressSearch.spec.ts
@@ -1,7 +1,38 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+const axiosMock = new MockAdapter(axios);
+
+// axiosMock を作った後にimportする事でMockに置き換えられる
+import { fetchAddressByPostalCode } from '../../repositories/implements/axios/address';
 import addressSearch from '../addressSearch';
 
 describe('addressSearch', () => {
-  it('should return a address', () => {
+  afterEach(() => {
+    axiosMock.restore();
+  });
+
+  it('should return a address', async () => {
+    const mockResponse = {
+      message: null,
+      results: [
+        {
+          address1: '東京都',
+          address2: '新宿区',
+          address3: '市谷加賀町',
+          kana1: 'ﾄｳｷｮｳﾄ',
+          kana2: 'ｼﾝｼﾞｭｸｸ',
+          kana3: 'ｲﾁｶﾞﾔｶｶﾞﾁｮｳ',
+          prefcode: '13',
+          zipcode: '1620062',
+        },
+      ],
+      status: 200,
+    };
+
+    axiosMock
+      .onGet('https://zipcloud.ibsnet.co.jp/api/search')
+      .reply(200, mockResponse);
+
     const request = {
       postalCode: '1620062',
     };
@@ -10,15 +41,17 @@ describe('addressSearch', () => {
       statusCode: 200,
       body: {
         postalCode: '1620062',
-        region: '東京',
-        locality: '市谷加賀町',
+        region: '東京都',
+        locality: '新宿区',
       },
     };
 
-    expect(addressSearch(request)).toStrictEqual(expected);
+    const actual = await addressSearch(request, fetchAddressByPostalCode);
+
+    expect(actual).toStrictEqual(expected);
   });
 
-  it('should return a NotAllowedPostalCode Error', () => {
+  it('should return a NotAllowedPostalCode Error', async () => {
     const request = {
       postalCode: '1000000',
     };
@@ -31,10 +64,12 @@ describe('addressSearch', () => {
       },
     };
 
-    expect(addressSearch(request)).toStrictEqual(expected);
+    const actual = await addressSearch(request, fetchAddressByPostalCode);
+
+    expect(actual).toStrictEqual(expected);
   });
 
-  it('should return a validation error', () => {
+  it('should return a validation error', async () => {
     const request = {
       postalCode: '12345678',
     };
@@ -49,6 +84,8 @@ describe('addressSearch', () => {
       },
     };
 
-    expect(addressSearch(request)).toStrictEqual(expected);
+    const actual = await addressSearch(request, fetchAddressByPostalCode);
+
+    expect(actual).toStrictEqual(expected);
   });
 });

--- a/src/api/v1/addressSearch.ts
+++ b/src/api/v1/addressSearch.ts
@@ -1,0 +1,90 @@
+import Ajv from 'ajv';
+import {
+  SuccessResponse,
+  ErrorResponse,
+  ValidationErrorResponse,
+} from '../Response';
+
+type Request = {
+  postalCode: string;
+};
+
+type ResponseBody = {
+  postalCode: string;
+  region: string;
+  locality: string;
+};
+
+type AddressSearchSuccessResponse = SuccessResponse<ResponseBody>;
+
+type ErrorCode = 'NotFoundAddress' | 'NotAllowedPostalCode';
+
+type ErrorMessage =
+  | 'address is not found'
+  | 'not allowed to search by that postalCode';
+
+type AddressSearchErrorResponse = ErrorResponse<ErrorCode, ErrorMessage>;
+
+const schema = {
+  type: 'object',
+  properties: {
+    postalCode: {
+      type: 'string',
+      minLength: 7,
+      maxLength: 7,
+    },
+  },
+  required: ['postalCode'],
+  additionalProperties: false,
+};
+
+const ajv = new Ajv({ allErrors: true });
+
+const validate = ajv.compile(schema);
+
+export const addressSearch = (
+  request: Request,
+):
+  | AddressSearchSuccessResponse
+  | AddressSearchErrorResponse
+  | ValidationErrorResponse => {
+  const valid = validate(request);
+
+  if (!valid) {
+    const validationErrors = validate.errors.map((value) => {
+      return {
+        key: value.instancePath.replace('/', ''),
+        reason: value.message,
+      };
+    });
+
+    return {
+      statusCode: 422,
+      body: {
+        message: 'Unprocessable Entity',
+        validationErrors,
+      },
+    };
+  }
+
+  if (request.postalCode === '1000000') {
+    return {
+      statusCode: 400,
+      body: {
+        code: 'NotAllowedPostalCode',
+        message: 'not allowed to search by that postalCode',
+      },
+    };
+  }
+
+  return {
+    statusCode: 200,
+    body: {
+      postalCode: '1620062',
+      region: '東京',
+      locality: '市谷加賀町',
+    },
+  };
+};
+
+export default addressSearch;

--- a/src/api/v1/addressSearch.ts
+++ b/src/api/v1/addressSearch.ts
@@ -4,6 +4,12 @@ import {
   ErrorResponse,
   ValidationErrorResponse,
 } from '../Response';
+import { FetchAddressByPostalCode } from '../repositories/interfaces/address';
+import {
+  FetchAddressByPostalCodeError,
+  FetchAddressByPostalCodeErrorMessage,
+} from '../repositories/errors/FetchAddressByPostalCodeError';
+import assertNever from '../utils/assertNever';
 
 type Request = {
   postalCode: string;
@@ -17,11 +23,12 @@ type ResponseBody = {
 
 type AddressSearchSuccessResponse = SuccessResponse<ResponseBody>;
 
-type ErrorCode = 'NotFoundAddress' | 'NotAllowedPostalCode';
+type ErrorCode = 'NotFoundAddress' | 'NotAllowedPostalCode' | 'UnexpectedError';
 
 type ErrorMessage =
   | 'address is not found'
-  | 'not allowed to search by that postalCode';
+  | 'not allowed to search by that postalCode'
+  | 'unexpected error';
 
 type AddressSearchErrorResponse = ErrorResponse<ErrorCode, ErrorMessage>;
 
@@ -42,49 +49,80 @@ const ajv = new Ajv({ allErrors: true });
 
 const validate = ajv.compile(schema);
 
-export const addressSearch = (
+export const addressSearch = async (
   request: Request,
-):
+  fetchAddressByPostalCode: FetchAddressByPostalCode,
+): Promise<
   | AddressSearchSuccessResponse
   | AddressSearchErrorResponse
-  | ValidationErrorResponse => {
-  const valid = validate(request);
+  | ValidationErrorResponse
+> => {
+  try {
+    const valid = validate(request);
 
-  if (!valid) {
-    const validationErrors = validate.errors.map((value) => {
+    if (!valid) {
+      const validationErrors = validate.errors.map((value) => {
+        return {
+          key: value.instancePath.replace('/', ''),
+          reason: value.message,
+        };
+      });
+
       return {
-        key: value.instancePath.replace('/', ''),
-        reason: value.message,
+        statusCode: 422,
+        body: {
+          message: 'Unprocessable Entity',
+          validationErrors,
+        },
       };
-    });
+    }
+
+    if (request.postalCode === '1000000') {
+      return {
+        statusCode: 400,
+        body: {
+          code: 'NotAllowedPostalCode',
+          message: 'not allowed to search by that postalCode',
+        },
+      };
+    }
+
+    const address = await fetchAddressByPostalCode(request.postalCode);
 
     return {
-      statusCode: 422,
-      body: {
-        message: 'Unprocessable Entity',
-        validationErrors,
-      },
+      statusCode: 200,
+      body: address,
     };
+  } catch (error) {
+    return createErrorResponse(error);
   }
+};
 
-  if (request.postalCode === '1000000') {
-    return {
-      statusCode: 400,
-      body: {
-        code: 'NotAllowedPostalCode',
-        message: 'not allowed to search by that postalCode',
-      },
-    };
+const createErrorResponse = (
+  error: FetchAddressByPostalCodeError,
+): AddressSearchErrorResponse => {
+  const errorMessage = error.message as FetchAddressByPostalCodeErrorMessage;
+
+  switch (errorMessage) {
+    case 'AddressDoseNotFoundError':
+      return {
+        statusCode: 404,
+        body: {
+          code: 'NotFoundAddress',
+          message: 'address is not found',
+        },
+      };
+    case 'UnexpectedError':
+      return {
+        statusCode: 500,
+        body: {
+          code: 'UnexpectedError',
+          message: 'unexpected error',
+        },
+      };
+    default:
+      return assertNever(errorMessage);
   }
-
-  return {
-    statusCode: 200,
-    body: {
-      postalCode: '1620062',
-      region: '東京',
-      locality: '市谷加賀町',
-    },
-  };
 };
 
 export default addressSearch;

--- a/src/functions/addressSearch/handler.ts
+++ b/src/functions/addressSearch/handler.ts
@@ -1,0 +1,27 @@
+import 'source-map-support/register';
+
+import type { ValidatedEventAPIGatewayProxyEvent } from '@libs/apiGateway';
+import { formatJsonResponse } from '@libs/apiGateway';
+import { middyfy } from '@libs/lambda';
+
+import defaultRequestHeader from '@constants/defaultRequestHeader';
+import defaultRequestBody from '@constants/defaultRequestBody';
+import defaultQueryParams from "@constants/defaultQueryParams";
+
+import pathParams from './pathParams';
+import addressSearch from "../../api/v1/addressSearch";
+
+const addressSearchHandler: ValidatedEventAPIGatewayProxyEvent<
+  typeof defaultRequestHeader,
+  typeof defaultRequestBody,
+  typeof pathParams,
+  typeof defaultQueryParams
+> = async (event) => {
+  const request = event.pathParameters;
+
+  const response = addressSearch(request);
+
+  return formatJsonResponse(response.statusCode, response.body);
+};
+
+export const main = middyfy(addressSearchHandler);

--- a/src/functions/addressSearch/handler.ts
+++ b/src/functions/addressSearch/handler.ts
@@ -6,10 +6,10 @@ import { middyfy } from '@libs/lambda';
 
 import defaultRequestHeader from '@constants/defaultRequestHeader';
 import defaultRequestBody from '@constants/defaultRequestBody';
-import defaultQueryParams from "@constants/defaultQueryParams";
+import defaultQueryParams from '@constants/defaultQueryParams';
 
 import pathParams from './pathParams';
-import addressSearch from "../../api/v1/addressSearch";
+import addressSearch from '../../api/v1/addressSearch';
 
 const addressSearchHandler: ValidatedEventAPIGatewayProxyEvent<
   typeof defaultRequestHeader,

--- a/src/functions/addressSearch/handler.ts
+++ b/src/functions/addressSearch/handler.ts
@@ -9,6 +9,8 @@ import defaultRequestBody from '@constants/defaultRequestBody';
 import defaultQueryParams from '@constants/defaultQueryParams';
 
 import pathParams from './pathParams';
+
+import { fetchAddressByPostalCode } from '../../api/repositories/implements/axios/address';
 import addressSearch from '../../api/v1/addressSearch';
 
 const addressSearchHandler: ValidatedEventAPIGatewayProxyEvent<
@@ -19,7 +21,7 @@ const addressSearchHandler: ValidatedEventAPIGatewayProxyEvent<
 > = async (event) => {
   const request = event.pathParameters;
 
-  const response = addressSearch(request);
+  const response = await addressSearch(request, fetchAddressByPostalCode);
 
   return formatJsonResponse(response.statusCode, response.body);
 };

--- a/src/functions/addressSearch/index.ts
+++ b/src/functions/addressSearch/index.ts
@@ -1,0 +1,13 @@
+import { handlerPath } from '@libs/handlerResolver';
+
+export default {
+  handler: `${handlerPath(__dirname)}/handler.main`,
+  events: [
+    {
+      httpApi: {
+        method: 'get',
+        path: '/addresses/{postalCode}',
+      },
+    },
+  ],
+};

--- a/src/functions/addressSearch/pathParams.ts
+++ b/src/functions/addressSearch/pathParams.ts
@@ -1,0 +1,11 @@
+export default {
+  type: 'object',
+  properties: {
+    postalCode: {
+      type: 'string',
+      minLength: 7,
+      maxLength: 7,
+    },
+  },
+  required: ['postalCode'],
+} as const;

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -1,2 +1,3 @@
 export { default as hello } from './hello';
 export { default as helloWithPath } from './helloWithPath';
+export { default as addressSearch } from './addressSearch';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1604,6 +1604,15 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
+axios-mock-server@^0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/axios-mock-server/-/axios-mock-server-0.19.1.tgz#5d7a3bbf78bbe07155e5d345f3f1cab76ebb0aa3"
+  integrity sha512-4Rh7eetDYq1KRqisvkflk+7LZ95zykIfBliV95da0rhtqjhq+yj661aOZIXIGyyWOwy3PtgHQ+vRtWWO5p4Osw==
+  dependencies:
+    chokidar "^3.5.1"
+    minimist "^1.2.5"
+    url-search-params-polyfill "^8.1.0"
+
 axios@^0.21.1:
   version "0.21.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
@@ -3223,6 +3232,11 @@ extend@^3.0.0, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
+extensible-custom-error@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/extensible-custom-error/-/extensible-custom-error-0.0.7.tgz#4d6cc86c71d60a0e11fa8d24972104720cd30305"
+  integrity sha512-1tgubPkgC+Qi2nUpulI7hGddHh0fA8hXu3P0LBUq2pamZL52KSJZqMu8Q3CiA6kf7Irn/CU1fJe6y4igHCwu4Q==
 
 external-editor@^3.0.3:
   version "3.1.0"
@@ -7639,6 +7653,11 @@ url-parse-lax@^3.0.0:
   integrity sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=
   dependencies:
     prepend-http "^2.0.0"
+
+url-search-params-polyfill@^8.1.0:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-8.1.1.tgz#9e69e4dba300a71ae7ad3cead62c7717fd99329f"
+  integrity sha512-KmkCs6SjE6t4ihrfW9JelAPQIIIFbJweaaSLTh/4AO+c58JlDcb+GbdPt8yr5lRcFg4rPswRFRRhBGpWwh0K/Q==
 
 url-to-options@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,24 +25,24 @@
     "@babel/highlight" "^7.12.13"
 
 "@babel/compat-data@^7.13.15":
-  version "7.13.15"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.13.15.tgz#7e8eea42d0b64fda2b375b22d06c605222e848f4"
-  integrity sha512-ltnibHKR1VnrU4ymHyQ/CXtNXI6yZC0oJThyW78Hft8XndANwi+9H+UIklBDraIjFEJzw8wmcM427oDd9KS5wA==
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.14.0.tgz#a901128bce2ad02565df95e6ecbf195cf9465919"
+  integrity sha512-vu9V3uMM/1o5Hl5OekMUowo3FqXLJSw+s+66nt0fSWVWTtmosdzn45JHOB3cPtZoe6CTBDzvSw0RdOY85Q37+Q==
 
 "@babel/core@^7.1.0", "@babel/core@^7.7.5":
-  version "7.13.16"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.13.16.tgz#7756ab24396cc9675f1c3fcd5b79fcce192ea96a"
-  integrity sha512-sXHpixBiWWFti0AV2Zq7avpTasr6sIAu7Y396c608541qAU2ui4a193m0KSQmfPSKFZLnQ3cvlKDOm3XkuXm3Q==
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.14.0.tgz#47299ff3ec8d111b493f1a9d04bf88c04e728d88"
+  integrity sha512-8YqpRig5NmIHlMLw09zMlPTvUVMILjqCOtVgu+TVNWEBvy9b5I3RRyhqnrV4hjgEK7n8P9OqvkWJAFmEL6Wwfw==
   dependencies:
     "@babel/code-frame" "^7.12.13"
-    "@babel/generator" "^7.13.16"
+    "@babel/generator" "^7.14.0"
     "@babel/helper-compilation-targets" "^7.13.16"
-    "@babel/helper-module-transforms" "^7.13.14"
-    "@babel/helpers" "^7.13.16"
-    "@babel/parser" "^7.13.16"
+    "@babel/helper-module-transforms" "^7.14.0"
+    "@babel/helpers" "^7.14.0"
+    "@babel/parser" "^7.14.0"
     "@babel/template" "^7.12.13"
-    "@babel/traverse" "^7.13.15"
-    "@babel/types" "^7.13.16"
+    "@babel/traverse" "^7.14.0"
+    "@babel/types" "^7.14.0"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
@@ -50,12 +50,12 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/generator@^7.13.16":
-  version "7.13.16"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.13.16.tgz#0befc287031a201d84cdfc173b46b320ae472d14"
-  integrity sha512-grBBR75UnKOcUWMp8WoDxNsWCFl//XCK6HWTrBQKTr5SV9f5g0pNOjdyzi/DTBv12S9GnYPInIXQBTky7OXEMg==
+"@babel/generator@^7.14.0":
+  version "7.14.1"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.14.1.tgz#1f99331babd65700183628da186f36f63d615c93"
+  integrity sha512-TMGhsXMXCP/O1WtQmZjpEYDhCYC9vFhayWZPJSZCGkPJgUqX0rF0wwtrYvnzVxIjcF80tkUertXVk5cwqi5cAQ==
   dependencies:
-    "@babel/types" "^7.13.16"
+    "@babel/types" "^7.14.1"
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
@@ -99,19 +99,19 @@
   dependencies:
     "@babel/types" "^7.13.12"
 
-"@babel/helper-module-transforms@^7.13.14":
-  version "7.13.14"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz#e600652ba48ccb1641775413cb32cfa4e8b495ef"
-  integrity sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==
+"@babel/helper-module-transforms@^7.14.0":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.14.0.tgz#8fcf78be220156f22633ee204ea81f73f826a8ad"
+  integrity sha512-L40t9bxIuGOfpIGA3HNkJhU9qYrf4y5A5LUSw7rGMSn+pcG8dfJ0g6Zval6YJGd2nEjI7oP00fRdnhLKndx6bw==
   dependencies:
     "@babel/helper-module-imports" "^7.13.12"
     "@babel/helper-replace-supers" "^7.13.12"
     "@babel/helper-simple-access" "^7.13.12"
     "@babel/helper-split-export-declaration" "^7.12.13"
-    "@babel/helper-validator-identifier" "^7.12.11"
+    "@babel/helper-validator-identifier" "^7.14.0"
     "@babel/template" "^7.12.13"
-    "@babel/traverse" "^7.13.13"
-    "@babel/types" "^7.13.14"
+    "@babel/traverse" "^7.14.0"
+    "@babel/types" "^7.14.0"
 
 "@babel/helper-optimise-call-expression@^7.12.13":
   version "7.12.13"
@@ -149,38 +149,38 @@
   dependencies:
     "@babel/types" "^7.12.13"
 
-"@babel/helper-validator-identifier@^7.12.11":
-  version "7.12.11"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
-  integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
+"@babel/helper-validator-identifier@^7.14.0":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz#d26cad8a47c65286b15df1547319a5d0bcf27288"
+  integrity sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==
 
 "@babel/helper-validator-option@^7.12.17":
   version "7.12.17"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz#d1fbf012e1a79b7eebbfdc6d270baaf8d9eb9831"
   integrity sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==
 
-"@babel/helpers@^7.13.16":
-  version "7.13.17"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.13.17.tgz#b497c7a00e9719d5b613b8982bda6ed3ee94caf6"
-  integrity sha512-Eal4Gce4kGijo1/TGJdqp3WuhllaMLSrW6XcL0ulyUAQOuxHcCafZE8KHg9857gcTehsm/v7RcOx2+jp0Ryjsg==
+"@babel/helpers@^7.14.0":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.14.0.tgz#ea9b6be9478a13d6f961dbb5f36bf75e2f3b8f62"
+  integrity sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==
   dependencies:
     "@babel/template" "^7.12.13"
-    "@babel/traverse" "^7.13.17"
-    "@babel/types" "^7.13.17"
+    "@babel/traverse" "^7.14.0"
+    "@babel/types" "^7.14.0"
 
 "@babel/highlight@^7.10.4", "@babel/highlight@^7.12.13":
-  version "7.13.10"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.13.10.tgz#a8b2a66148f5b27d666b15d81774347a731d52d1"
-  integrity sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.14.0.tgz#3197e375711ef6bf834e67d0daec88e4f46113cf"
+  integrity sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.12.11"
+    "@babel/helper-validator-identifier" "^7.14.0"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.12.13", "@babel/parser@^7.13.16":
-  version "7.13.16"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.16.tgz#0f18179b0448e6939b1f3f5c4c355a3a9bcdfd37"
-  integrity sha512-6bAg36mCwuqLO0hbR+z7PHuqWiCeP7Dzg73OpQwsAB1Eb8HnGEz5xYBzCfbu+YjoaJsJs+qheDxVAuqbt3ILEw==
+"@babel/parser@^7.1.0", "@babel/parser@^7.12.13", "@babel/parser@^7.14.0":
+  version "7.14.1"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.1.tgz#1bd644b5db3f5797c4479d89ec1817fe02b84c47"
+  integrity sha512-muUGEKu8E/ftMTPlNp+mc6zL3E9zKWmF5sDHZ5MSsoTP9Wyz64AhEf9kD08xYJ7w6Hdcu8H550ircnPyWSIF0Q==
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
@@ -275,26 +275,26 @@
     "@babel/parser" "^7.12.13"
     "@babel/types" "^7.12.13"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.13.0", "@babel/traverse@^7.13.13", "@babel/traverse@^7.13.15", "@babel/traverse@^7.13.17":
-  version "7.13.17"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.13.17.tgz#c85415e0c7d50ac053d758baec98b28b2ecfeea3"
-  integrity sha512-BMnZn0R+X6ayqm3C3To7o1j7Q020gWdqdyP50KEoVqaCO2c/Im7sYZSmVgvefp8TTMQ+9CtwuBp0Z1CZ8V3Pvg==
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.13.0", "@babel/traverse@^7.14.0":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.14.0.tgz#cea0dc8ae7e2b1dec65f512f39f3483e8cc95aef"
+  integrity sha512-dZ/a371EE5XNhTHomvtuLTUyx6UEoJmYX+DT5zBCQN3McHemsuIaKKYqsc/fs26BEkHs/lBZy0J571LP5z9kQA==
   dependencies:
     "@babel/code-frame" "^7.12.13"
-    "@babel/generator" "^7.13.16"
+    "@babel/generator" "^7.14.0"
     "@babel/helper-function-name" "^7.12.13"
     "@babel/helper-split-export-declaration" "^7.12.13"
-    "@babel/parser" "^7.13.16"
-    "@babel/types" "^7.13.17"
+    "@babel/parser" "^7.14.0"
+    "@babel/types" "^7.14.0"
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.12.13", "@babel/types@^7.13.12", "@babel/types@^7.13.14", "@babel/types@^7.13.16", "@babel/types@^7.13.17", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
-  version "7.13.17"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.13.17.tgz#48010a115c9fba7588b4437dd68c9469012b38b4"
-  integrity sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==
+"@babel/types@^7.0.0", "@babel/types@^7.12.13", "@babel/types@^7.13.12", "@babel/types@^7.14.0", "@babel/types@^7.14.1", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
+  version "7.14.1"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.1.tgz#095bd12f1c08ab63eff6e8f7745fa7c9cc15a9db"
+  integrity sha512-S13Qe85fzLs3gYRUnrpyeIrBJIMYv33qSTg1qoBwiG6nPKwUWAD9odSzWhEedpwOIzSEI6gbdQIWEMiCI42iBA==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.12.11"
+    "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -639,7 +639,7 @@
     node-fetch "^2.6.0"
     shortid "^2.2.14"
 
-"@serverless/components@^3.9.0":
+"@serverless/components@^3.9.1":
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/@serverless/components/-/components-3.9.1.tgz#eb3d0a26a98ca8e70155dd6d32620845b9ca8dbb"
   integrity sha512-Eo8ubz8Id40K09mRH8OheHUinruNSjj4wMYZ5rRLxsMiFfT8wVCIr/hBClNN+VU9jd8SPyvfKGen7MoLSj+eYA==
@@ -1080,12 +1080,12 @@
     "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@^4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.22.0.tgz#3d5f29bb59e61a9dba1513d491b059e536e16dbc"
-  integrity sha512-U8SP9VOs275iDXaL08Ln1Fa/wLXfj5aTr/1c0t0j6CdbOnxh+TruXu1p4I0NAvdPBQgoPjHsgKn28mOi0FzfoA==
+  version "4.22.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.22.1.tgz#6bcdbaa4548553ab861b4e5f34936ead1349a543"
+  integrity sha512-kVTAghWDDhsvQ602tHBc6WmQkdaYbkcTwZu+7l24jtJiYvm9l+/y/b2BZANEezxPDiX5MK2ZecE+9BFi/YJryw==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.22.0"
-    "@typescript-eslint/scope-manager" "4.22.0"
+    "@typescript-eslint/experimental-utils" "4.22.1"
+    "@typescript-eslint/scope-manager" "4.22.1"
     debug "^4.1.1"
     functional-red-black-tree "^1.0.1"
     lodash "^4.17.15"
@@ -1093,60 +1093,60 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.22.0.tgz#68765167cca531178e7b650a53456e6e0bef3b1f"
-  integrity sha512-xJXHHl6TuAxB5AWiVrGhvbGL8/hbiCQ8FiWwObO3r0fnvBdrbWEDy1hlvGQOAWc6qsCWuWMKdVWlLAEMpxnddg==
+"@typescript-eslint/experimental-utils@4.22.1":
+  version "4.22.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.22.1.tgz#3938a5c89b27dc9a39b5de63a62ab1623ab27497"
+  integrity sha512-svYlHecSMCQGDO2qN1v477ax/IDQwWhc7PRBiwAdAMJE7GXk5stF4Z9R/8wbRkuX/5e9dHqbIWxjeOjckK3wLQ==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/scope-manager" "4.22.0"
-    "@typescript-eslint/types" "4.22.0"
-    "@typescript-eslint/typescript-estree" "4.22.0"
+    "@typescript-eslint/scope-manager" "4.22.1"
+    "@typescript-eslint/types" "4.22.1"
+    "@typescript-eslint/typescript-estree" "4.22.1"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
 "@typescript-eslint/parser@^4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.22.0.tgz#e1637327fcf796c641fe55f73530e90b16ac8fe8"
-  integrity sha512-z/bGdBJJZJN76nvAY9DkJANYgK3nlRstRRi74WHm3jjgf2I8AglrSY+6l7ogxOmn55YJ6oKZCLLy+6PW70z15Q==
+  version "4.22.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.22.1.tgz#a95bda0fd01d994a15fc3e99dc984294f25c19cc"
+  integrity sha512-l+sUJFInWhuMxA6rtirzjooh8cM/AATAe3amvIkqKFeMzkn85V+eLzb1RyuXkHak4dLfYzOmF6DXPyflJvjQnw==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.22.0"
-    "@typescript-eslint/types" "4.22.0"
-    "@typescript-eslint/typescript-estree" "4.22.0"
+    "@typescript-eslint/scope-manager" "4.22.1"
+    "@typescript-eslint/types" "4.22.1"
+    "@typescript-eslint/typescript-estree" "4.22.1"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.22.0.tgz#ed411545e61161a8d702e703a4b7d96ec065b09a"
-  integrity sha512-OcCO7LTdk6ukawUM40wo61WdeoA7NM/zaoq1/2cs13M7GyiF+T4rxuA4xM+6LeHWjWbss7hkGXjFDRcKD4O04Q==
+"@typescript-eslint/scope-manager@4.22.1":
+  version "4.22.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.22.1.tgz#5bb357f94f9cd8b94e6be43dd637eb73b8f355b4"
+  integrity sha512-d5bAiPBiessSmNi8Amq/RuLslvcumxLmyhf1/Xa9IuaoFJ0YtshlJKxhlbY7l2JdEk3wS0EnmnfeJWSvADOe0g==
   dependencies:
-    "@typescript-eslint/types" "4.22.0"
-    "@typescript-eslint/visitor-keys" "4.22.0"
+    "@typescript-eslint/types" "4.22.1"
+    "@typescript-eslint/visitor-keys" "4.22.1"
 
-"@typescript-eslint/types@4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.22.0.tgz#0ca6fde5b68daf6dba133f30959cc0688c8dd0b6"
-  integrity sha512-sW/BiXmmyMqDPO2kpOhSy2Py5w6KvRRsKZnV0c4+0nr4GIcedJwXAq+RHNK4lLVEZAJYFltnnk1tJSlbeS9lYA==
+"@typescript-eslint/types@4.22.1":
+  version "4.22.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.22.1.tgz#bf99c6cec0b4a23d53a61894816927f2adad856a"
+  integrity sha512-2HTkbkdAeI3OOcWbqA8hWf/7z9c6gkmnWNGz0dKSLYLWywUlkOAQ2XcjhlKLj5xBFDf8FgAOF5aQbnLRvgNbCw==
 
-"@typescript-eslint/typescript-estree@4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.22.0.tgz#b5d95d6d366ff3b72f5168c75775a3e46250d05c"
-  integrity sha512-TkIFeu5JEeSs5ze/4NID+PIcVjgoU3cUQUIZnH3Sb1cEn1lBo7StSV5bwPuJQuoxKXlzAObjYTilOEKRuhR5yg==
+"@typescript-eslint/typescript-estree@4.22.1":
+  version "4.22.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.22.1.tgz#dca379eead8cdfd4edc04805e83af6d148c164f9"
+  integrity sha512-p3We0pAPacT+onSGM+sPR+M9CblVqdA9F1JEdIqRVlxK5Qth4ochXQgIyb9daBomyQKAXbygxp1aXQRV0GC79A==
   dependencies:
-    "@typescript-eslint/types" "4.22.0"
-    "@typescript-eslint/visitor-keys" "4.22.0"
+    "@typescript-eslint/types" "4.22.1"
+    "@typescript-eslint/visitor-keys" "4.22.1"
     debug "^4.1.1"
     globby "^11.0.1"
     is-glob "^4.0.1"
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/visitor-keys@4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.0.tgz#169dae26d3c122935da7528c839f42a8a42f6e47"
-  integrity sha512-nnMu4F+s4o0sll6cBSsTeVsT4cwxB7zECK3dFxzEjPBii9xLpq4yqqsy/FU5zMfan6G60DKZSCXAa3sHJZrcYw==
+"@typescript-eslint/visitor-keys@4.22.1":
+  version "4.22.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.1.tgz#6045ae25a11662c671f90b3a403d682dfca0b7a6"
+  integrity sha512-WPkOrIRm+WCLZxXQHCi+WG8T2MMTUFR70rWjdWYddLT7cEfb2P4a3O/J2U1FBVsSFTocXLCoXWY6MZGejeStvQ==
   dependencies:
-    "@typescript-eslint/types" "4.22.0"
+    "@typescript-eslint/types" "4.22.1"
     eslint-visitor-keys "^2.0.0"
 
 "@webassemblyjs/ast@1.11.0":
@@ -1309,9 +1309,9 @@ acorn@^7.1.1, acorn@^7.4.0:
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
 acorn@^8.1.0, acorn@^8.2.1:
-  version "8.2.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.2.1.tgz#0d36af126fb6755095879c1dc6fd7edf7d60a5fb"
-  integrity sha512-z716cpm5TX4uzOzILx8PavOE6C6DKshHDw1aQN52M/yNSqE9s5O8SMfyhCCfCJ3HmTL0NkVOi+8a/55T7YB3bg==
+  version "8.2.4"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.2.4.tgz#caba24b08185c3b56e3168e97d15ed17f4d31fd0"
+  integrity sha512-Ibt84YwBDDA890eDiDCEqcbwvHlBvzzDkU2cGBBDDI1QWT12jTiXIOn2CIw5KK4i6N5Z2HUxwYjzriDyqaqqZg==
 
 adm-zip@^0.4.13:
   version "0.4.16"
@@ -1579,10 +1579,10 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-aws-sdk@^2.891.0:
-  version "2.895.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.895.0.tgz#71b8ded8f972ca869b1310eebd2924695b009ec3"
-  integrity sha512-f8lkEcItfGaYPhJkdbymLth8K0aZ6aMiuoSr/0r2GaFFLq9neg2WUL0dgqSmVUGf55ZMDbwjcBurhJPrcBbDbw==
+aws-sdk@^2.897.0:
+  version "2.899.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.899.0.tgz#fac90b8926707b3e9dcd1e7d5937cfa71c0be5ca"
+  integrity sha512-k8jSANDQGvTyyj1f/7Hj4SWaV61/gjj/BopRmavAr6n1ayjXtUeVrV8G29+ABD3V82pHXDqLq47bqNmZ9m86xQ==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -1604,14 +1604,13 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios-mock-server@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/axios-mock-server/-/axios-mock-server-0.19.1.tgz#5d7a3bbf78bbe07155e5d345f3f1cab76ebb0aa3"
-  integrity sha512-4Rh7eetDYq1KRqisvkflk+7LZ95zykIfBliV95da0rhtqjhq+yj661aOZIXIGyyWOwy3PtgHQ+vRtWWO5p4Osw==
+axios-mock-adapter@^1.19.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.19.0.tgz#9d72e321a6c5418e1eff067aa99761a86c5188a4"
+  integrity sha512-D+0U4LNPr7WroiBDvWilzTMYPYTuZlbo6BI8YHZtj7wYQS8NkARlP9KBt8IWWHTQJ0q/8oZ0ClPBtKCCkx8cQg==
   dependencies:
-    chokidar "^3.5.1"
-    minimist "^1.2.5"
-    url-search-params-polyfill "^8.1.0"
+    fast-deep-equal "^3.1.3"
+    is-buffer "^2.0.3"
 
 axios@^0.21.1:
   version "0.21.1"
@@ -1843,13 +1842,13 @@ browser-process-hrtime@^1.0.0:
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
 browserslist@^4.14.5:
-  version "4.16.5"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.5.tgz#952825440bca8913c62d0021334cbe928ef062ae"
-  integrity sha512-C2HAjrM1AI/djrpAUU/tr4pml1DqLIzJKSLDBXBrNErl9ZCCTXdhwxdJjYc16953+mBWf7Lw+uUJgpgb8cN71A==
+  version "4.16.6"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.6.tgz#d7901277a5a88e554ed305b183ec9b0c08f66fa2"
+  integrity sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==
   dependencies:
-    caniuse-lite "^1.0.30001214"
+    caniuse-lite "^1.0.30001219"
     colorette "^1.2.2"
-    electron-to-chromium "^1.3.719"
+    electron-to-chromium "^1.3.723"
     escalade "^3.1.1"
     node-releases "^1.1.71"
 
@@ -1924,7 +1923,7 @@ buffers@~0.1.1:
   resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
   integrity sha1-skV5w77U1tOWru5tmorn9Ugqt7s=
 
-builtin-modules@^3.0.0, builtin-modules@^3.1.0:
+builtin-modules@^3.0.0, builtin-modules@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.2.0.tgz#45d5db99e7ee5e6bc4f362e008bf917ab5049887"
   integrity sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==
@@ -2016,10 +2015,10 @@ camelcase@^6.0.0, camelcase@^6.2.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
-caniuse-lite@^1.0.30001214:
-  version "1.0.30001219"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001219.tgz#5bfa5d0519f41f993618bd318f606a4c4c16156b"
-  integrity sha512-c0yixVG4v9KBc/tQ2rlbB3A/bgBFRvl8h8M4IeUbqCca4gsiCfvtaheUssbnux/Mb66Vjz7x8yYjDgYcNQOhyQ==
+caniuse-lite@^1.0.30001219:
+  version "1.0.30001221"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001221.tgz#b916721ddf59066cfbe96c5c9a77cf7ae5c52e65"
+  integrity sha512-b9TOZfND3uGSLjMOrLh8XxSQ41x8mX+9MLJYDM4AAHLfaZHttrLNPrScWjVnBITRZbY5sPpCt7X85n7VSLZ+/g==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -2769,10 +2768,10 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-electron-to-chromium@^1.3.719:
-  version "1.3.723"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.723.tgz#52769a75635342a4db29af5f1e40bd3dad02c877"
-  integrity sha512-L+WXyXI7c7+G1V8ANzRsPI5giiimLAUDC6Zs1ojHHPhYXb3k/iTABFmWjivEtsWrRQymjnO66/rO2ZTABGdmWg==
+electron-to-chromium@^1.3.723:
+  version "1.3.726"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.726.tgz#6d3c577e5f5a48904ba891464740896c05e3bdb1"
+  integrity sha512-dw7WmrSu/JwtACiBzth8cuKf62NKL1xVJuNvyOg0jvruN/n4NLtGYoTzciQquCPNaS2eR+BT5GrxHbslfc/w1w==
 
 emittery@^0.7.1:
   version "0.7.2"
@@ -2997,9 +2996,9 @@ eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
 eslint-visitor-keys@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
-  integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
+  integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
 eslint@^7.25.0:
   version "7.25.0"
@@ -3271,7 +3270,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -3544,7 +3543,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fs2@^0.3.8:
+fs2@^0.3.9:
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/fs2/-/fs2-0.3.9.tgz#3869e5b2ec7e0622eaa5f4373df540d3d427a9fb"
   integrity sha512-WsOqncODWRlkjwll+73bAxVW3JPChDgaPX3DT4iTTm73UmG4VgALa7LaFblP232/DN60itkOrPZ8kaP1feksGQ==
@@ -4119,6 +4118,11 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@^2.0.3:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
 is-builtin-module@^3.1.0:
   version "3.1.0"
@@ -5465,18 +5469,18 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-ncjsm@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ncjsm/-/ncjsm-4.1.0.tgz#4af4a57d560211cca9783ea875f361cb801f108d"
-  integrity sha512-YElRGtbz5iIartetOI3we+XAkcGE29F0SdNC0qRy500/u4WceQd2z9Nhlx24OHmIDIKz9MHdJwf/fkSG0hdWcQ==
+ncjsm@^4.1.0, ncjsm@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/ncjsm/-/ncjsm-4.2.0.tgz#7b2d752c3a42db5f6a2c5ff6934cf66fb1bb5e38"
+  integrity sha512-L2Qij4PTy7Bs4TB24zs7FLIAYJTaR5JPvSig5hIcO059LnMCNgy6MfHHNyg8s/aekPKrTqKX90gBGt3NNGvhdw==
   dependencies:
-    builtin-modules "^3.1.0"
+    builtin-modules "^3.2.0"
     deferred "^0.7.11"
     es5-ext "^0.10.53"
     es6-set "^0.1.5"
     find-requires "^1.0.0"
-    fs2 "^0.3.8"
-    type "^2.0.0"
+    fs2 "^0.3.9"
+    type "^2.5.0"
 
 neo-async@^2.6.2:
   version "2.6.2"
@@ -5751,9 +5755,9 @@ p-cancelable@^1.0.0:
   integrity sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
 
 p-cancelable@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.1.0.tgz#4d51c3b91f483d02a0d300765321fca393d758dd"
-  integrity sha512-HAZyB3ZodPo+BDpb4/Iu7Jv4P6cSazBz9ZM0ChhEXp70scx834aWCEjQRwgt41UzzejUAPdbqqONfRWTPYrPAQ==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.1.1.tgz#aab7fbd416582fa32a3db49859c122487c5ed2cf"
+  integrity sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==
 
 p-each-series@^2.1.0:
   version "2.2.0"
@@ -5899,6 +5903,11 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+path2@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/path2/-/path2-0.1.0.tgz#639828942cdbda44a41a45b074ae8873483b4efa"
+  integrity sha1-Y5golCzb2kSkGkWwdK6Ic0g7Tvo=
 
 pend@~1.2.0:
   version "1.2.0"
@@ -6051,9 +6060,9 @@ prompts@^2.0.1:
     sisteransi "^1.0.5"
 
 protobufjs@^6.9.0:
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.0.tgz#b890a2d3f64c62f0395e1e000d39ff91634bafb7"
-  integrity sha512-i4usrGD86mtOLnoTwUsVXphDY7yHM2rDiV3JU4Ix43BOtHi0DHy5rSCciX8MRHSYHaxnoc0TcpwEBlrNUAxvQQ==
+  version "6.11.2"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.2.tgz#de39fabd4ed32beaa08e9bb1e30d08544c1edf8b"
+  integrity sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
@@ -6578,18 +6587,18 @@ serverless-webpack@^5.4.2:
     ts-node ">= 8.3.0"
 
 serverless@^2.38.0:
-  version "2.38.0"
-  resolved "https://registry.yarnpkg.com/serverless/-/serverless-2.38.0.tgz#7dbf000b3a2159762fda79aa3875f1df400d2422"
-  integrity sha512-M/PAO3e3XoAdWvAd02iq+K4KkWmdxx8hLMCPg4tne0XZaLF5pTOvBWTdACgkuuikQDdo+Px8dl4idsIciEGezQ==
+  version "2.39.1"
+  resolved "https://registry.yarnpkg.com/serverless/-/serverless-2.39.1.tgz#d13b53a98d72c224a184258ba985898dfbee8e08"
+  integrity sha512-I2yOV/6HJG2xTXCI1N0uTSTXNyM/PJf38IR6RtVDoRxqFfxyYyVCzF2yYrYZ9r182RazG0Hc6WhNDIpqy+DBKQ==
   dependencies:
     "@serverless/cli" "^1.5.2"
-    "@serverless/components" "^3.9.0"
+    "@serverless/components" "^3.9.1"
     "@serverless/enterprise-plugin" "^4.5.3"
     "@serverless/utils" "^4.1.0"
     ajv "^6.12.6"
     ajv-keywords "^3.5.2"
     archiver "^5.3.0"
-    aws-sdk "^2.891.0"
+    aws-sdk "^2.897.0"
     bluebird "^3.7.2"
     boxen "^5.0.1"
     cachedir "^2.3.0"
@@ -6618,9 +6627,10 @@ serverless@^2.38.0:
     lodash "^4.17.21"
     memoizee "^0.4.15"
     micromatch "^4.0.4"
-    ncjsm "^4.1.0"
+    ncjsm "^4.2.0"
     node-fetch "^2.6.1"
     object-hash "^2.1.1"
+    path2 "^0.1.0"
     promise-queue "^2.2.5"
     replaceall "^0.1.6"
     semver "^7.3.5"
@@ -7654,11 +7664,6 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-search-params-polyfill@^8.1.0:
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-8.1.1.tgz#9e69e4dba300a71ae7ad3cead62c7717fd99329f"
-  integrity sha512-KmkCs6SjE6t4ihrfW9JelAPQIIIFbJweaaSLTh/4AO+c58JlDcb+GbdPt8yr5lRcFg4rPswRFRRhBGpWwh0K/Q==
-
 url-to-options@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/url-to-options/-/url-to-options-1.0.1.tgz#1505a03a289a48cbd7a434efbaeec5055f5633a9"
@@ -7788,9 +7793,9 @@ webpack-sources@^2.1.1:
     source-map "^0.6.1"
 
 webpack@^5.36.1:
-  version "5.36.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.36.1.tgz#d82bad3384f84ed45a8de3844c31730f56361ab7"
-  integrity sha512-2u25a82T+6quAxSlzEpN/R/RICwt20ONU3z3Ko05S8KVH9FXILcBYb2hD/rQtZT5y7lRAIsIIs05pdndY7ourQ==
+  version "5.36.2"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.36.2.tgz#6ef1fb2453ad52faa61e78d486d353d07cca8a0f"
+  integrity sha512-XJumVnnGoH2dV+Pk1VwgY4YT6AiMKpVoudUFCNOXMIVrEKPUgEwdIfWPjIuGLESAiS8EdIHX5+TiJz/5JccmRg==
   dependencies:
     "@types/eslint-scope" "^3.7.0"
     "@types/estree" "^0.0.47"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/aws-serverless-node-api-boilerplate/issues/4

# Doneの定義
- 外部APIに依存したAPIが実装されている事
- 外部APIへの通信がMock化されたテストコードが実装されている事

# 変更点概要

以下の外部APIを使って住所検索が出来るAPIを実装。

```
curl -v 'https://zipcloud.ibsnet.co.jp/api/search?zipcode=1620060'
```

この外部APIへの通信部分を `axios-mock-adapter` を使ってMock化してある。

# 補足情報
最初は https://github.com/solufa/axios-mock-server を使おうと思ったが、APIが別の外部APIに依存しているような今回のケースでは `axios-mock-adapter` を使ってMock化したほうが適切だと判断した。