### PR TITLE
RDS Proxyに接続するサンプルAPIを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "ajv": "^8.2.0",
     "axios": "^0.21.1",
     "extensible-custom-error": "^0.0.7",
+    "mysql2": "^2.2.5",
     "source-map-support": "^0.5.19"
   },
   "devDependencies": {

--- a/serverless.ts
+++ b/serverless.ts
@@ -1,5 +1,5 @@
 import type { AWS } from '@serverless/typescript';
-import {hello, helloWithPath, addressSearch} from '@functions/index';
+import {hello, helloWithPath, addressSearch, createUser} from '@functions/index';
 
 const serverlessConfiguration: AWS = {
   service: 'serverless-node-api',
@@ -23,11 +23,40 @@ const serverlessConfiguration: AWS = {
     },
     environment: {
       AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
+      DB_WRITER_HOSTNAME: process.env.DB_WRITER_HOSTNAME,
+      DB_READER_HOSTNAME: process.env.DB_READER_HOSTNAME,
+      DB_USERNAME: process.env.DB_USERNAME,
+      DB_PASSWORD: process.env.DB_PASSWORD,
+      DB_NAME: process.env.DB_NAME,
     },
     lambdaHashingVersion: '20201221',
+    vpc: {
+      securityGroupIds: [process.env.SECURITY_GROUP_ID],
+      subnetIds: [
+        process.env.SUBNET_ID_1,
+        process.env.SUBNET_ID_2,
+        process.env.SUBNET_ID_3,
+      ],
+    },
+    iam: {
+      role: {
+        statements: [
+          {
+            Effect: 'Allow',
+            Action: [
+              'ec2:CreateNetworkInterface',
+              'ec2:DescribeNetworkInterfaces',
+              'ec2:DetachNetworkInterface',
+              'ec2:DeleteNetworkInterface',
+            ],
+            Resource: '*'
+          },
+        ],
+      }
+    }
   },
   // import the function via paths
-  functions: { hello, helloWithPath, addressSearch },
+  functions: { hello, helloWithPath, addressSearch, createUser },
 };
 
 module.exports = serverlessConfiguration;

--- a/src/functions/createUser/handler.ts
+++ b/src/functions/createUser/handler.ts
@@ -1,0 +1,78 @@
+// TODO RDS Proxyの動作確認用
+import 'source-map-support/register';
+
+import type { ValidatedEventAPIGatewayProxyEvent } from '@libs/apiGateway';
+import { formatJsonResponse } from '@libs/apiGateway';
+import { middyfy } from '@libs/lambda';
+
+import { createConnection, Connection } from 'mysql2/promise';
+
+import defaultRequestHeader from '@constants/defaultRequestHeader';
+import defaultPathParams from '@constants/defaultPathParams';
+import defaultQueryParams from '@constants/defaultQueryParams';
+
+import requestBody from './requestBody';
+
+let connection: Connection;
+
+const createMysqlConnection = (): Promise<Connection> => {
+  return createConnection({
+    host: process.env.DB_WRITER_HOSTNAME,
+    user: process.env.DB_USERNAME,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+  });
+};
+
+const createUserHandler: ValidatedEventAPIGatewayProxyEvent<
+  typeof defaultRequestHeader,
+  typeof requestBody,
+  typeof defaultPathParams,
+  typeof defaultQueryParams
+> = async (event) => {
+  try {
+    connection = await createMysqlConnection();
+  } catch (error) {
+    const response = {
+      statusCode: 500,
+      body: {
+        code: 'DB_ERROR',
+        message: 'DB接続に失敗しました。',
+      },
+    };
+
+    return formatJsonResponse(500, response.body);
+  }
+
+  try {
+    const request = event.body;
+
+    const sql = 'SELECT * FROM users';
+
+    const [rows] = await connection.execute(sql);
+
+    const response = {
+      statusCode: 200,
+      body: {
+        request,
+        users: rows,
+      },
+    };
+
+    return formatJsonResponse(200, response.body);
+  } catch (error) {
+    const response = {
+      statusCode: 500,
+      body: {
+        code: 'DB_ERROR',
+        message: 'DB接続に失敗しました。',
+      },
+    };
+
+    return formatJsonResponse(500, response.body);
+  } finally {
+    await connection.end();
+  }
+};
+
+export const main = middyfy(createUserHandler);

--- a/src/functions/createUser/index.ts
+++ b/src/functions/createUser/index.ts
@@ -1,0 +1,14 @@
+import { handlerPath } from '@libs/handlerResolver';
+
+export default {
+  handler: `${handlerPath(__dirname)}/handler.main`,
+  timeout: 25,
+  events: [
+    {
+      httpApi: {
+        method: 'post',
+        path: '/users',
+      },
+    },
+  ],
+};

--- a/src/functions/createUser/requestBody.ts
+++ b/src/functions/createUser/requestBody.ts
@@ -1,0 +1,9 @@
+export default {
+  type: 'object',
+  properties: {
+    email: {
+      type: 'email',
+    },
+  },
+  required: ['email'],
+} as const;

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -1,3 +1,4 @@
 export { default as hello } from './hello';
 export { default as helloWithPath } from './helloWithPath';
 export { default as addressSearch } from './addressSearch';
+export { default as createUser } from './createUser';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2645,7 +2645,7 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-denque@^1.3.0:
+denque@^1.3.0, denque@^1.4.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/denque/-/denque-1.5.0.tgz#773de0686ff2d8ec2ff92914316a47b73b1c73de"
   integrity sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==
@@ -3585,6 +3585,13 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
+generate-function@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.3.1.tgz#f069617690c10c868e73b8465746764f97c3479f"
+  integrity sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==
+  dependencies:
+    is-property "^1.0.2"
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
@@ -3957,6 +3964,13 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.11:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+iconv-lite@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.2.tgz#ce13d1875b0c3a674bd6a04b7f76b01b1b6ded01"
+  integrity sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 ieee754@1.1.13:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
@@ -4271,6 +4285,11 @@ is-promise@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
   integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
+
+is-property@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
+  integrity sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=
 
 is-retry-allowed@^1.1.0:
   version "1.2.0"
@@ -5189,6 +5208,14 @@ lowercase-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
+lru-cache@^4.1.3:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
@@ -5426,6 +5453,27 @@ mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
+mysql2@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/mysql2/-/mysql2-2.2.5.tgz#72624ffb4816f80f96b9c97fedd8c00935f9f340"
+  integrity sha512-XRqPNxcZTpmFdXbJqb+/CtYVLCx14x1RTeNMD4954L331APu75IC74GDqnZMEt1kwaXy6TySo55rF2F3YJS78g==
+  dependencies:
+    denque "^1.4.1"
+    generate-function "^2.3.1"
+    iconv-lite "^0.6.2"
+    long "^4.0.0"
+    lru-cache "^6.0.0"
+    named-placeholders "^1.1.2"
+    seq-queue "^0.0.5"
+    sqlstring "^2.3.2"
+
+named-placeholders@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/named-placeholders/-/named-placeholders-1.1.2.tgz#ceb1fbff50b6b33492b5cf214ccf5e39cef3d0e8"
+  integrity sha512-wiFWqxoLL3PGVReSZpjLVxyJ1bRqe+KKJVbr4hGs1KWfTZTQyezHFBbuKj9hsizHyGV2ne7EMjHdxEGAybD5SA==
+  dependencies:
+    lru-cache "^4.1.3"
 
 nan@^2.14.1:
   version "2.14.2"
@@ -6083,6 +6131,11 @@ prr@~1.0.1:
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
 
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
+
 psl@^1.1.28, psl@^1.1.33:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
@@ -6494,7 +6547,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -6563,6 +6616,11 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+seq-queue@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/seq-queue/-/seq-queue-0.0.5.tgz#d56812e1c017a6e4e7c3e3a37a1da6d78dd3c93e"
+  integrity sha1-1WgS4cAXpuTnw+Ojeh2m143TyT4=
 
 serialize-javascript@^5.0.1:
   version "5.0.1"
@@ -6947,6 +7005,11 @@ sprintf-kit@^2.0.0:
   integrity sha512-/0d2YTn8ZFVpIPAU230S9ZLF8WDkSSRWvh/UOLM7zzvkCchum1TtouRgyV8OfgOaYilSGU4lSSqzwBXJVlAwUw==
   dependencies:
     es5-ext "^0.10.46"
+
+sqlstring@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/sqlstring/-/sqlstring-2.3.2.tgz#cdae7169389a1375b18e885f2e60b3e460809514"
+  integrity sha512-vF4ZbYdKS8OnoJAWBmMxCQDkiEBkGQYU7UZPtL8flbDRSNkhaXvRJ279ZtI6M+zDaQovVU4tuRgzK5fVhvFAhg==
 
 sshpk@^1.7.0:
   version "1.16.1"
@@ -7997,6 +8060,11 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/aws-serverless-node-api-boilerplate/issues/5

# Doneの定義
- RDS Proxyの接続が確認出来るAPIが実装されている事

# 変更点概要
RDS Proxyへの接続確認を行う為のAPIを仮実装。

```
curl -X POST -kv \
-H "Content-Type: application/json" \
-H "Authorization: Bearer YOUR ACCESS TOKEN" \
-d \
'
{
  "email": "keita@exmple.com"
}
' \
https://aaaaaaaaa.execute-api.ap-northeast-1.amazonaws.com/users | jq
```

# 補足情報
本格的な実装は別のPRで行う。

RDS Proxyの作成は https://github.com/keitakn/my-terraform/pull/52 で行っている。