### PR TITLE
MySQL用のDocker containerを追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+
+services:
+  mysql:
+    build:
+      context: .
+      dockerfile: docker/mysql/Dockerfile
+    environment:
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USERNAME}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+    ports:
+      - "63306:3306"
+    volumes:
+      - nekochans-serverless-api-mysql:/var/lib/mysql
+      - ./docker/mysql:/docker-entrypoint-initdb.d
+volumes:
+  nekochans-serverless-api-mysql:

--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,0 +1,5 @@
+FROM mysql:5.7
+
+LABEL maintainer="https://github.com/nekochans"
+
+COPY ./docker/mysql/config/my.cnf /etc/mysql/conf.d/my.cnf

--- a/docker/mysql/config/my.cnf
+++ b/docker/mysql/config/my.cnf
@@ -1,0 +1,20 @@
+[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_bin
+skip-character-set-client-handshake
+default-storage-engine=InnoDB
+innodb_file_per_table=1
+innodb_large_prefix=1
+innodb_file_format=Barracuda
+innodb_default_row_format=DYNAMIC
+default_password_lifetime = 0
+slow_query_log = 1
+long_query_time = 0.1
+slow_query_log_file = /var/log/mysql-slow-query.log
+
+[mysql]
+auto-rehash
+default-character-set = utf8mb4
+
+[mysqldump]
+default-character-set = utf8mb4

--- a/docker/mysql/initial.sql
+++ b/docker/mysql/initial.sql
@@ -3,3 +3,4 @@
 -- データベース 'serverless_test' への権限を付与
 CREATE DATABASE IF NOT EXISTS serverless_test CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 GRANT ALL ON serverless_test.* TO `serverless_test_user`@`%` IDENTIFIED BY 'Serverless_Test_User|8888';
+GRANT ALL ON *.* TO `serverless_test_user`@`%` IDENTIFIED BY 'Serverless_Test_User|8888';

--- a/docker/mysql/initial.sql
+++ b/docker/mysql/initial.sql
@@ -1,0 +1,5 @@
+-- 'serverless_test' というデータベースを作成
+-- 'serverless_test_user' というユーザー名のユーザーを作成
+-- データベース 'serverless_test' への権限を付与
+CREATE DATABASE IF NOT EXISTS serverless_test CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+GRANT ALL ON serverless_test.* TO `serverless_test_user`@`%` IDENTIFIED BY 'Serverless_Test_User|8888';


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/aws-serverless-node-api-boilerplate/issues/5

# Doneの定義
- MySQL用のコンテナが起動出来る状態になっている事

# 変更点概要
MySQL用のコンテナを起動する為の `Dockerfile` と `docker-compose.yml` を追加。

# 補足情報
RDS Proxyで利用しているRDSはMySQL互換のAuroraなのでMySQLのバージョンは5.7系を利用。