### PR TITLE
handler.ts内の関数命名規則を統一、他軽微なリファクタリング

### DIFF
--- a/src/api/domain/types/userEntity.ts
+++ b/src/api/domain/types/userEntity.ts
@@ -1,5 +1,5 @@
 export type UserEntity = {
-  userId: number;
+  id: number;
   email: emailEntity;
   phoneNumbers?: phoneNumberEntity[];
 };

--- a/src/api/v1/__tests__/createUser.spec.ts
+++ b/src/api/v1/__tests__/createUser.spec.ts
@@ -30,7 +30,7 @@ describe.skip('createUser', () => {
       statusCode: 201,
       body: {
         user: {
-          userId: 1,
+          id: 1,
           email: {
             id: 1,
             email: request.email,
@@ -54,7 +54,7 @@ describe.skip('createUser', () => {
       statusCode: 201,
       body: {
         user: {
-          userId: 1,
+          id: 1,
           email: {
             id: 1,
             email: request.email,

--- a/src/api/v1/__tests__/hello.spec.ts
+++ b/src/api/v1/__tests__/hello.spec.ts
@@ -1,6 +1,6 @@
-import sayHello from '../sayHello';
+import hello from '../hello';
 
-describe('sayHello', () => {
+describe('hello', () => {
   it('should return a success message', () => {
     const request = {
       name: 'Moko',
@@ -14,7 +14,7 @@ describe('sayHello', () => {
       },
     };
 
-    expect(sayHello(request)).toStrictEqual(expected);
+    expect(hello(request)).toStrictEqual(expected);
   });
 
   it('should return a Error', () => {
@@ -31,7 +31,7 @@ describe('sayHello', () => {
       },
     };
 
-    expect(sayHello(request)).toStrictEqual(expected);
+    expect(hello(request)).toStrictEqual(expected);
   });
 
   it('should return a validation error', () => {
@@ -51,6 +51,6 @@ describe('sayHello', () => {
       },
     };
 
-    expect(sayHello(request)).toStrictEqual(expected);
+    expect(hello(request)).toStrictEqual(expected);
   });
 });

--- a/src/api/v1/createUser.ts
+++ b/src/api/v1/createUser.ts
@@ -161,7 +161,7 @@ const createUserEntity = async (prisma: PrismaClient, newUser: users) => {
   });
 
   const userEntity = {
-    userId: responseData.id,
+    id: responseData.id,
     email: {
       id: responseData.users_emails.id,
       email: responseData.users_emails.email,

--- a/src/api/v1/hello.ts
+++ b/src/api/v1/hello.ts
@@ -40,7 +40,7 @@ const ajv = new Ajv({ allErrors: true });
 
 const validate = ajv.compile(schema);
 
-export const sayHello = (
+export const hello = (
   request: Request,
 ):
   | SayHelloSuccessResponse
@@ -83,4 +83,4 @@ export const sayHello = (
   };
 };
 
-export default sayHello;
+export default hello;

--- a/src/functions/hello/handler.ts
+++ b/src/functions/hello/handler.ts
@@ -8,17 +8,17 @@ import defaultQueryParams from '@constants/defaultQueryParams';
 
 import requestHeader from './requestHeader';
 import requestBody from './requestBody';
-import sayHello from '../../api/v1/sayHello';
+import hello from '../../api/v1/hello';
 
-const hello: ValidatedEventAPIGatewayProxyEvent<
+const helloHandler: ValidatedEventAPIGatewayProxyEvent<
   typeof requestHeader,
   typeof requestBody,
   typeof defaultPathParams,
   typeof defaultQueryParams
 > = async (event) => {
-  const apiRes = sayHello(event.body);
+  const apiRes = hello(event.body);
 
   return formatJsonResponse(apiRes.statusCode, apiRes.body);
 };
 
-export const main = middyfy(hello);
+export const main = middyfy(helloHandler);

--- a/src/functions/helloWithPath/handler.ts
+++ b/src/functions/helloWithPath/handler.ts
@@ -10,7 +10,7 @@ import defaultRequestBody from '@constants/defaultRequestBody';
 import pathParams from './pathParams';
 import queryParams from './queryParams';
 
-const helloWithPath: ValidatedEventAPIGatewayProxyEvent<
+const helloWithPathHandler: ValidatedEventAPIGatewayProxyEvent<
   typeof defaultRequestHeader,
   typeof defaultRequestBody,
   typeof pathParams,
@@ -24,4 +24,4 @@ const helloWithPath: ValidatedEventAPIGatewayProxyEvent<
   return formatJsonResponse(200, responseBody);
 };
 
-export const main = middyfy(helloWithPath);
+export const main = middyfy(helloWithPathHandler);


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/aws-serverless-node-api-boilerplate/issues/14

# Doneの定義
- https://github.com/nekochans/aws-serverless-node-api-boilerplate/issues/14 の完了の定義を満たしている事

# 変更点概要
handler.ts内の関数は全て○○Handlerという命名に統一。

PRの趣旨とは外れるが、userIdの命名が冗長だったので `user.id` に変更。