### PR TITLE
HTTPステータスコードとエラーメッセージを型安全に扱えるようにリファクタリング

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,4 +9,9 @@ module.exports = {
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest'
   },
+  moduleNameMapper: {
+    "@constants/(.*)": "<rootDir>/src/constants/$1",
+    "@functions/(.*)": "<rootDir>/src/functions/$1",
+    "@libs/(.*)": "<rootDir>/src/libs/$1"
+  },
 };

--- a/src/api/Response.ts
+++ b/src/api/Response.ts
@@ -14,7 +14,7 @@ export type ErrorResponse<T, U> = {
 };
 
 export type ValidationErrorResponse = {
-  statusCode: 422;
+  statusCode: typeof HttpStatusCode.unprocessableEntity;
   body: {
     message: 'Unprocessable Entity';
     validationErrors: { key: string; reason: string }[];

--- a/src/api/repositories/errors/FetchAddressByPostalCodeError.ts
+++ b/src/api/repositories/errors/FetchAddressByPostalCodeError.ts
@@ -3,8 +3,8 @@ import ExtensibleCustomError from 'extensible-custom-error';
 export class FetchAddressByPostalCodeError extends ExtensibleCustomError {}
 
 export const FetchAddressByPostalCodeErrorMessage = {
-  addressDoseNotFoundError: 'AddressDoseNotFoundError',
-  unexpectedError: 'UnexpectedError',
+  addressDoseNotFoundError: 'addressDoseNotFoundError',
+  unexpectedError: 'unexpectedError',
 } as const;
 
 export type FetchAddressByPostalCodeErrorMessage =

--- a/src/api/repositories/implements/axios/address.ts
+++ b/src/api/repositories/implements/axios/address.ts
@@ -57,7 +57,7 @@ export const fetchAddressByPostalCode: FetchAddressByPostalCode = async (
   } catch (error) {
     return Promise.reject(
       new FetchAddressByPostalCodeError(
-        FetchAddressByPostalCodeErrorMessage.addressDoseNotFoundError,
+        FetchAddressByPostalCodeErrorMessage.unexpectedError,
         error,
       ),
     );

--- a/src/api/utils/valueOf.ts
+++ b/src/api/utils/valueOf.ts
@@ -1,0 +1,1 @@
+export type valueOf<T> = T[keyof T];

--- a/src/api/v1/__tests__/addressSearch.spec.ts
+++ b/src/api/v1/__tests__/addressSearch.spec.ts
@@ -63,7 +63,7 @@ describe('addressSearch', () => {
     const expected: AddressSearchErrorResponse = {
       statusCode: 400,
       body: {
-        code: 'NotAllowedPostalCode',
+        code: 'notAllowedPostalCode',
         message: 'not allowed to search by that postalCode',
       },
     };
@@ -91,7 +91,7 @@ describe('addressSearch', () => {
     const expected: AddressSearchErrorResponse = {
       statusCode: 404,
       body: {
-        code: 'NotFoundAddress',
+        code: 'notFoundAddress',
         message: 'address is not found',
       },
     };

--- a/src/api/v1/__tests__/addressSearch.spec.ts
+++ b/src/api/v1/__tests__/addressSearch.spec.ts
@@ -9,6 +9,7 @@ import addressSearch, {
   AddressSearchSuccessResponse,
 } from '../addressSearch';
 import { ValidationErrorResponse } from '../../Response';
+import { HttpStatusCode } from '@constants/HttpStatusCode';
 
 describe('addressSearch', () => {
   afterEach(() => {
@@ -30,19 +31,19 @@ describe('addressSearch', () => {
           zipcode: '1620062',
         },
       ],
-      status: 200,
+      status: HttpStatusCode.ok,
     };
 
     axiosMock
       .onGet('https://zipcloud.ibsnet.co.jp/api/search')
-      .reply(200, mockResponse);
+      .reply(HttpStatusCode.ok, mockResponse);
 
     const request = {
       postalCode: '1620062',
     };
 
     const expected: AddressSearchSuccessResponse = {
-      statusCode: 200,
+      statusCode: HttpStatusCode.ok,
       body: {
         postalCode: '1620062',
         region: '東京都',
@@ -61,7 +62,7 @@ describe('addressSearch', () => {
     };
 
     const expected: AddressSearchErrorResponse = {
-      statusCode: 400,
+      statusCode: HttpStatusCode.badRequest,
       body: {
         code: 'notAllowedPostalCode',
         message: 'not allowed to search by that postalCode',
@@ -77,19 +78,19 @@ describe('addressSearch', () => {
     const mockResponse = {
       message: null,
       results: null,
-      status: 200,
+      status: HttpStatusCode.ok,
     };
 
     axiosMock
       .onGet('https://zipcloud.ibsnet.co.jp/api/search')
-      .reply(200, mockResponse);
+      .reply(HttpStatusCode.ok, mockResponse);
 
     const request = {
       postalCode: '1620000',
     };
 
     const expected: AddressSearchErrorResponse = {
-      statusCode: 404,
+      statusCode: HttpStatusCode.notFound,
       body: {
         code: 'notFoundAddress',
         message: 'address is not found',
@@ -107,7 +108,7 @@ describe('addressSearch', () => {
     };
 
     const expected: ValidationErrorResponse = {
-      statusCode: 422,
+      statusCode: HttpStatusCode.unprocessableEntity,
       body: {
         message: `Unprocessable Entity`,
         validationErrors: [

--- a/src/api/v1/__tests__/addressSearch.spec.ts
+++ b/src/api/v1/__tests__/addressSearch.spec.ts
@@ -4,7 +4,11 @@ const axiosMock = new MockAdapter(axios);
 
 // axiosMock を作った後にimportする事でMockに置き換えられる
 import { fetchAddressByPostalCode } from '../../repositories/implements/axios/address';
-import addressSearch from '../addressSearch';
+import addressSearch, {
+  AddressSearchErrorResponse,
+  AddressSearchSuccessResponse,
+} from '../addressSearch';
+import { ValidationErrorResponse } from '../../Response';
 
 describe('addressSearch', () => {
   afterEach(() => {
@@ -37,7 +41,7 @@ describe('addressSearch', () => {
       postalCode: '1620062',
     };
 
-    const expected = {
+    const expected: AddressSearchSuccessResponse = {
       statusCode: 200,
       body: {
         postalCode: '1620062',
@@ -56,7 +60,7 @@ describe('addressSearch', () => {
       postalCode: '1000000',
     };
 
-    const expected = {
+    const expected: AddressSearchErrorResponse = {
       statusCode: 400,
       body: {
         code: 'NotAllowedPostalCode',
@@ -84,7 +88,7 @@ describe('addressSearch', () => {
       postalCode: '1620000',
     };
 
-    const expected = {
+    const expected: AddressSearchErrorResponse = {
       statusCode: 404,
       body: {
         code: 'NotFoundAddress',
@@ -102,7 +106,7 @@ describe('addressSearch', () => {
       postalCode: '12345678',
     };
 
-    const expected = {
+    const expected: ValidationErrorResponse = {
       statusCode: 422,
       body: {
         message: `Unprocessable Entity`,

--- a/src/api/v1/__tests__/createUser.spec.ts
+++ b/src/api/v1/__tests__/createUser.spec.ts
@@ -1,5 +1,9 @@
-import createUser from '../createUser';
+import createUser, {
+  CreateUserErrorResponse,
+  CreateUserSuccessResponse,
+} from '../createUser';
 import { PrismaClient } from '@prisma/client';
+import { ValidationErrorResponse } from '../../Response';
 
 describe.skip('createUser', () => {
   let prisma: PrismaClient;
@@ -26,7 +30,7 @@ describe.skip('createUser', () => {
       email: 'aaa@exmple.com',
     };
 
-    const expected = {
+    const expected: CreateUserSuccessResponse = {
       statusCode: 201,
       body: {
         user: {
@@ -50,7 +54,7 @@ describe.skip('createUser', () => {
       phoneNumber: '08012345678',
     };
 
-    const expected = {
+    const expected: CreateUserSuccessResponse = {
       statusCode: 201,
       body: {
         user: {
@@ -74,7 +78,7 @@ describe.skip('createUser', () => {
       email: 'ccc@exmple.com',
     };
 
-    const expected = {
+    const expected: CreateUserErrorResponse = {
       statusCode: 400,
       body: {
         code: 'EmailAlreadyRegistered',
@@ -94,7 +98,7 @@ describe.skip('createUser', () => {
       email: '12345678',
     };
 
-    const expected = {
+    const expected: ValidationErrorResponse = {
       statusCode: 422,
       body: {
         message: `Unprocessable Entity`,

--- a/src/api/v1/__tests__/createUser.spec.ts
+++ b/src/api/v1/__tests__/createUser.spec.ts
@@ -81,8 +81,8 @@ describe.skip('createUser', () => {
     const expected: CreateUserErrorResponse = {
       statusCode: 400,
       body: {
-        code: 'EmailAlreadyRegistered',
-        message: `Email address is already registered`,
+        code: 'emailAlreadyRegistered',
+        message: `email is already registered`,
       },
     };
 

--- a/src/api/v1/__tests__/createUser.spec.ts
+++ b/src/api/v1/__tests__/createUser.spec.ts
@@ -4,6 +4,7 @@ import createUser, {
 } from '../createUser';
 import { PrismaClient } from '@prisma/client';
 import { ValidationErrorResponse } from '../../Response';
+import { HttpStatusCode } from '@constants/HttpStatusCode';
 
 describe.skip('createUser', () => {
   let prisma: PrismaClient;
@@ -31,7 +32,7 @@ describe.skip('createUser', () => {
     };
 
     const expected: CreateUserSuccessResponse = {
-      statusCode: 201,
+      statusCode: HttpStatusCode.created,
       body: {
         user: {
           id: 1,
@@ -55,7 +56,7 @@ describe.skip('createUser', () => {
     };
 
     const expected: CreateUserSuccessResponse = {
-      statusCode: 201,
+      statusCode: HttpStatusCode.created,
       body: {
         user: {
           id: 1,
@@ -79,7 +80,7 @@ describe.skip('createUser', () => {
     };
 
     const expected: CreateUserErrorResponse = {
-      statusCode: 400,
+      statusCode: HttpStatusCode.badRequest,
       body: {
         code: 'emailAlreadyRegistered',
         message: `email is already registered`,
@@ -99,7 +100,7 @@ describe.skip('createUser', () => {
     };
 
     const expected: ValidationErrorResponse = {
-      statusCode: 422,
+      statusCode: HttpStatusCode.unprocessableEntity,
       body: {
         message: `Unprocessable Entity`,
         validationErrors: [

--- a/src/api/v1/__tests__/hello.spec.ts
+++ b/src/api/v1/__tests__/hello.spec.ts
@@ -1,4 +1,7 @@
-import hello from '../hello';
+import hello, {
+  SayHelloErrorResponse,
+  SayHelloSuccessResponse,
+} from '../hello';
 
 describe('hello', () => {
   it('should return a success message', () => {
@@ -7,7 +10,7 @@ describe('hello', () => {
       status: 1,
     };
 
-    const expected = {
+    const expected: SayHelloSuccessResponse = {
       statusCode: 200,
       body: {
         message: `Hello ${request.name}, welcome to the exciting Serverless world! Your Status is ${request.status}!`,
@@ -23,7 +26,7 @@ describe('hello', () => {
       status: 1,
     };
 
-    const expected = {
+    const expected: SayHelloErrorResponse = {
       statusCode: 400,
       body: {
         code: 'NotAllowedMessage',

--- a/src/api/v1/__tests__/hello.spec.ts
+++ b/src/api/v1/__tests__/hello.spec.ts
@@ -2,6 +2,7 @@ import hello, {
   SayHelloErrorResponse,
   SayHelloSuccessResponse,
 } from '../hello';
+import { HttpStatusCode } from '@constants/HttpStatusCode';
 
 describe('hello', () => {
   it('should return a success message', () => {
@@ -11,7 +12,7 @@ describe('hello', () => {
     };
 
     const expected: SayHelloSuccessResponse = {
-      statusCode: 200,
+      statusCode: HttpStatusCode.ok,
       body: {
         message: `Hello ${request.name}, welcome to the exciting Serverless world! Your Status is ${request.status}!`,
       },
@@ -27,7 +28,7 @@ describe('hello', () => {
     };
 
     const expected: SayHelloErrorResponse = {
-      statusCode: 400,
+      statusCode: HttpStatusCode.badRequest,
       body: {
         code: 'notAllowedMessage',
         message: 'message is not allowed',
@@ -44,7 +45,7 @@ describe('hello', () => {
     };
 
     const expected = {
-      statusCode: 422,
+      statusCode: HttpStatusCode.unprocessableEntity,
       body: {
         message: `Unprocessable Entity`,
         validationErrors: [

--- a/src/api/v1/__tests__/hello.spec.ts
+++ b/src/api/v1/__tests__/hello.spec.ts
@@ -29,8 +29,8 @@ describe('hello', () => {
     const expected: SayHelloErrorResponse = {
       statusCode: 400,
       body: {
-        code: 'NotAllowedMessage',
-        message: 'NotAllowedMessage',
+        code: 'notAllowedMessage',
+        message: 'message is not allowed',
       },
     };
 

--- a/src/api/v1/__tests__/hello.spec.ts
+++ b/src/api/v1/__tests__/hello.spec.ts
@@ -1,7 +1,4 @@
-import hello, {
-  SayHelloErrorResponse,
-  SayHelloSuccessResponse,
-} from '../hello';
+import hello, { HelloErrorResponse, HelloSuccessResponse } from '../hello';
 import { HttpStatusCode } from '@constants/HttpStatusCode';
 
 describe('hello', () => {
@@ -11,7 +8,7 @@ describe('hello', () => {
       status: 1,
     };
 
-    const expected: SayHelloSuccessResponse = {
+    const expected: HelloSuccessResponse = {
       statusCode: HttpStatusCode.ok,
       body: {
         message: `Hello ${request.name}, welcome to the exciting Serverless world! Your Status is ${request.status}!`,
@@ -27,7 +24,7 @@ describe('hello', () => {
       status: 1,
     };
 
-    const expected: SayHelloErrorResponse = {
+    const expected: HelloErrorResponse = {
       statusCode: HttpStatusCode.badRequest,
       body: {
         code: 'notAllowedMessage',

--- a/src/api/v1/addressSearch.ts
+++ b/src/api/v1/addressSearch.ts
@@ -23,7 +23,7 @@ type ResponseBody = {
   locality: string;
 };
 
-type AddressSearchSuccessResponse = SuccessResponse<ResponseBody>;
+export type AddressSearchSuccessResponse = SuccessResponse<ResponseBody>;
 
 type Errors = {
   NotFoundAddress: 'address is not found';
@@ -34,7 +34,7 @@ type Errors = {
 type ErrorCode = keyof Errors;
 type ErrorMessage = valueOf<Errors>;
 
-type AddressSearchErrorResponse = ErrorResponse<ErrorCode, ErrorMessage>;
+export type AddressSearchErrorResponse = ErrorResponse<ErrorCode, ErrorMessage>;
 
 const schema = {
   type: 'object',

--- a/src/api/v1/addressSearch.ts
+++ b/src/api/v1/addressSearch.ts
@@ -10,6 +10,7 @@ import {
   FetchAddressByPostalCodeErrorMessage,
 } from '../repositories/errors/FetchAddressByPostalCodeError';
 import assertNever from '../utils/assertNever';
+import { HttpStatusCode } from '../../constants/HttpStatusCode';
 
 type Request = {
   postalCode: string;
@@ -69,7 +70,7 @@ export const addressSearch = async (
       });
 
       return {
-        statusCode: 422,
+        statusCode: HttpStatusCode.unprocessableEntity,
         body: {
           message: 'Unprocessable Entity',
           validationErrors,
@@ -79,7 +80,7 @@ export const addressSearch = async (
 
     if (request.postalCode === '1000000') {
       return {
-        statusCode: 400,
+        statusCode: HttpStatusCode.badRequest,
         body: {
           code: 'NotAllowedPostalCode',
           message: 'not allowed to search by that postalCode',
@@ -90,7 +91,7 @@ export const addressSearch = async (
     const address = await fetchAddressByPostalCode(request.postalCode);
 
     return {
-      statusCode: 200,
+      statusCode: HttpStatusCode.ok,
       body: address,
     };
   } catch (error) {
@@ -106,7 +107,7 @@ const createErrorResponse = (
   switch (errorMessage) {
     case 'AddressDoseNotFoundError':
       return {
-        statusCode: 404,
+        statusCode: HttpStatusCode.notFound,
         body: {
           code: 'NotFoundAddress',
           message: 'address is not found',
@@ -114,7 +115,7 @@ const createErrorResponse = (
       };
     case 'UnexpectedError':
       return {
-        statusCode: 500,
+        statusCode: HttpStatusCode.internalServerError,
         body: {
           code: 'UnexpectedError',
           message: 'unexpected error',

--- a/src/api/v1/addressSearch.ts
+++ b/src/api/v1/addressSearch.ts
@@ -108,7 +108,7 @@ const createErrorResponse = (
   const errorMessage = error.message as FetchAddressByPostalCodeErrorMessage;
 
   switch (errorMessage) {
-    case 'AddressDoseNotFoundError':
+    case 'addressDoseNotFoundError':
       return {
         statusCode: HttpStatusCode.notFound,
         body: {
@@ -116,7 +116,7 @@ const createErrorResponse = (
           message: 'address is not found',
         },
       };
-    case 'UnexpectedError':
+    case 'unexpectedError':
       return {
         statusCode: HttpStatusCode.internalServerError,
         body: {

--- a/src/api/v1/addressSearch.ts
+++ b/src/api/v1/addressSearch.ts
@@ -26,9 +26,9 @@ type ResponseBody = {
 export type AddressSearchSuccessResponse = SuccessResponse<ResponseBody>;
 
 type Errors = {
-  NotFoundAddress: 'address is not found';
-  NotAllowedPostalCode: 'not allowed to search by that postalCode';
-  UnexpectedError: 'unexpected error';
+  notFoundAddress: 'address is not found';
+  notAllowedPostalCode: 'not allowed to search by that postalCode';
+  unexpectedError: 'unexpected error';
 };
 
 type ErrorCode = keyof Errors;
@@ -85,7 +85,7 @@ export const addressSearch = async (
       return {
         statusCode: HttpStatusCode.badRequest,
         body: {
-          code: 'NotAllowedPostalCode',
+          code: 'notAllowedPostalCode',
           message: 'not allowed to search by that postalCode',
         },
       };
@@ -112,7 +112,7 @@ const createErrorResponse = (
       return {
         statusCode: HttpStatusCode.notFound,
         body: {
-          code: 'NotFoundAddress',
+          code: 'notFoundAddress',
           message: 'address is not found',
         },
       };
@@ -120,7 +120,7 @@ const createErrorResponse = (
       return {
         statusCode: HttpStatusCode.internalServerError,
         body: {
-          code: 'UnexpectedError',
+          code: 'unexpectedError',
           message: 'unexpected error',
         },
       };

--- a/src/api/v1/addressSearch.ts
+++ b/src/api/v1/addressSearch.ts
@@ -10,7 +10,7 @@ import {
   FetchAddressByPostalCodeErrorMessage,
 } from '../repositories/errors/FetchAddressByPostalCodeError';
 import assertNever from '../utils/assertNever';
-import { HttpStatusCode } from '../../constants/HttpStatusCode';
+import { HttpStatusCode } from '@constants/HttpStatusCode';
 
 type Request = {
   postalCode: string;

--- a/src/api/v1/addressSearch.ts
+++ b/src/api/v1/addressSearch.ts
@@ -25,14 +25,14 @@ type ResponseBody = {
 
 type AddressSearchSuccessResponse = SuccessResponse<ResponseBody>;
 
-type errors = {
+type Errors = {
   NotFoundAddress: 'address is not found';
   NotAllowedPostalCode: 'not allowed to search by that postalCode';
   UnexpectedError: 'unexpected error';
 };
 
-type ErrorCode = keyof errors;
-type ErrorMessage = valueOf<errors>;
+type ErrorCode = keyof Errors;
+type ErrorMessage = valueOf<Errors>;
 
 type AddressSearchErrorResponse = ErrorResponse<ErrorCode, ErrorMessage>;
 

--- a/src/api/v1/addressSearch.ts
+++ b/src/api/v1/addressSearch.ts
@@ -11,6 +11,7 @@ import {
 } from '../repositories/errors/FetchAddressByPostalCodeError';
 import assertNever from '../utils/assertNever';
 import { HttpStatusCode } from '@constants/HttpStatusCode';
+import { valueOf } from '../utils/valueOf';
 
 type Request = {
   postalCode: string;
@@ -24,12 +25,14 @@ type ResponseBody = {
 
 type AddressSearchSuccessResponse = SuccessResponse<ResponseBody>;
 
-type ErrorCode = 'NotFoundAddress' | 'NotAllowedPostalCode' | 'UnexpectedError';
+type errors = {
+  NotFoundAddress: 'address is not found';
+  NotAllowedPostalCode: 'not allowed to search by that postalCode';
+  UnexpectedError: 'unexpected error';
+};
 
-type ErrorMessage =
-  | 'address is not found'
-  | 'not allowed to search by that postalCode'
-  | 'unexpected error';
+type ErrorCode = keyof errors;
+type ErrorMessage = valueOf<errors>;
 
 type AddressSearchErrorResponse = ErrorResponse<ErrorCode, ErrorMessage>;
 

--- a/src/api/v1/createUser.ts
+++ b/src/api/v1/createUser.ts
@@ -10,6 +10,7 @@ import {
 } from '../Response';
 
 import { UserEntity } from '../domain/types/userEntity';
+import { HttpStatusCode } from '../../constants/HttpStatusCode';
 
 type Request = {
   email: string;
@@ -69,7 +70,7 @@ export const createUser = async (
       });
 
       return {
-        statusCode: 422,
+        statusCode: HttpStatusCode.unprocessableEntity,
         body: {
           message: 'Unprocessable Entity',
           validationErrors,
@@ -85,7 +86,7 @@ export const createUser = async (
 
     if (user) {
       return {
-        statusCode: 400,
+        statusCode: HttpStatusCode.badRequest,
         body: {
           code: 'EmailAlreadyRegistered',
           message: 'Email address is already registered',
@@ -98,7 +99,7 @@ export const createUser = async (
     const userEntity = await createUserEntity(prisma, newUser);
 
     return {
-      statusCode: 201,
+      statusCode: HttpStatusCode.created,
       body: {
         user: userEntity,
       },
@@ -111,7 +112,7 @@ export const createUser = async (
       error?.meta?.target === 'uq_users_emails_02'
     ) {
       return {
-        statusCode: 400,
+        statusCode: HttpStatusCode.badRequest,
         body: {
           code: 'EmailAlreadyRegistered',
           message: 'Email address is already registered',
@@ -120,7 +121,7 @@ export const createUser = async (
     }
 
     return {
-      statusCode: 500,
+      statusCode: HttpStatusCode.internalServerError,
       body: {
         code: 'EmailAlreadyRegistered',
         message: 'Email address is already registered',

--- a/src/api/v1/createUser.ts
+++ b/src/api/v1/createUser.ts
@@ -11,6 +11,7 @@ import {
 
 import { UserEntity } from '../domain/types/userEntity';
 import { HttpStatusCode } from '@constants/HttpStatusCode';
+import { valueOf } from '../utils/valueOf';
 
 type Request = {
   email: string;
@@ -23,9 +24,12 @@ type ResponseBody = {
 
 type CreateUserSuccessResponse = SuccessResponse<ResponseBody>;
 
-type ErrorCode = 'EmailAlreadyRegistered';
+type errors = {
+  EmailAlreadyRegistered: 'Email address is already registered';
+};
 
-type ErrorMessage = 'Email address is already registered';
+type ErrorCode = keyof errors;
+type ErrorMessage = valueOf<errors>;
 
 type CreateUserErrorResponse = ErrorResponse<ErrorCode, ErrorMessage>;
 

--- a/src/api/v1/createUser.ts
+++ b/src/api/v1/createUser.ts
@@ -24,12 +24,12 @@ type ResponseBody = {
 
 type CreateUserSuccessResponse = SuccessResponse<ResponseBody>;
 
-type errors = {
+type Errors = {
   EmailAlreadyRegistered: 'Email address is already registered';
 };
 
-type ErrorCode = keyof errors;
-type ErrorMessage = valueOf<errors>;
+type ErrorCode = keyof Errors;
+type ErrorMessage = valueOf<Errors>;
 
 type CreateUserErrorResponse = ErrorResponse<ErrorCode, ErrorMessage>;
 

--- a/src/api/v1/createUser.ts
+++ b/src/api/v1/createUser.ts
@@ -25,7 +25,7 @@ type ResponseBody = {
 export type CreateUserSuccessResponse = SuccessResponse<ResponseBody>;
 
 type Errors = {
-  EmailAlreadyRegistered: 'Email address is already registered';
+  emailAlreadyRegistered: 'email is already registered';
 };
 
 type ErrorCode = keyof Errors;
@@ -92,8 +92,8 @@ export const createUser = async (
       return {
         statusCode: HttpStatusCode.badRequest,
         body: {
-          code: 'EmailAlreadyRegistered',
-          message: 'Email address is already registered',
+          code: 'emailAlreadyRegistered',
+          message: 'email is already registered',
         },
       };
     }
@@ -118,8 +118,8 @@ export const createUser = async (
       return {
         statusCode: HttpStatusCode.badRequest,
         body: {
-          code: 'EmailAlreadyRegistered',
-          message: 'Email address is already registered',
+          code: 'emailAlreadyRegistered',
+          message: 'email is already registered',
         },
       };
     }
@@ -127,8 +127,8 @@ export const createUser = async (
     return {
       statusCode: HttpStatusCode.internalServerError,
       body: {
-        code: 'EmailAlreadyRegistered',
-        message: 'Email address is already registered',
+        code: 'emailAlreadyRegistered',
+        message: 'email is already registered',
       },
     };
   } finally {

--- a/src/api/v1/createUser.ts
+++ b/src/api/v1/createUser.ts
@@ -22,7 +22,7 @@ type ResponseBody = {
   user: UserEntity;
 };
 
-type CreateUserSuccessResponse = SuccessResponse<ResponseBody>;
+export type CreateUserSuccessResponse = SuccessResponse<ResponseBody>;
 
 type Errors = {
   EmailAlreadyRegistered: 'Email address is already registered';
@@ -31,7 +31,7 @@ type Errors = {
 type ErrorCode = keyof Errors;
 type ErrorMessage = valueOf<Errors>;
 
-type CreateUserErrorResponse = ErrorResponse<ErrorCode, ErrorMessage>;
+export type CreateUserErrorResponse = ErrorResponse<ErrorCode, ErrorMessage>;
 
 const schema = {
   type: 'object',

--- a/src/api/v1/createUser.ts
+++ b/src/api/v1/createUser.ts
@@ -10,7 +10,7 @@ import {
 } from '../Response';
 
 import { UserEntity } from '../domain/types/userEntity';
-import { HttpStatusCode } from '../../constants/HttpStatusCode';
+import { HttpStatusCode } from '@constants/HttpStatusCode';
 
 type Request = {
   email: string;

--- a/src/api/v1/hello.ts
+++ b/src/api/v1/hello.ts
@@ -12,7 +12,7 @@ type Request = {
   status: number;
 };
 
-export type SayHelloSuccessResponse = SuccessResponse<{ message: string }>;
+export type HelloSuccessResponse = SuccessResponse<{ message: string }>;
 
 export type Errors = {
   notAllowedMessage: 'message is not allowed';
@@ -21,7 +21,7 @@ export type Errors = {
 type ErrorCode = keyof Errors;
 type ErrorMessage = valueOf<Errors>;
 
-export type SayHelloErrorResponse = ErrorResponse<ErrorCode, ErrorMessage>;
+export type HelloErrorResponse = ErrorResponse<ErrorCode, ErrorMessage>;
 
 const schema = {
   type: 'object',
@@ -47,10 +47,7 @@ const validate = ajv.compile(schema);
 
 export const hello = (
   request: Request,
-):
-  | SayHelloSuccessResponse
-  | SayHelloErrorResponse
-  | ValidationErrorResponse => {
+): HelloSuccessResponse | HelloErrorResponse | ValidationErrorResponse => {
   const valid = validate(request);
 
   if (!valid) {

--- a/src/api/v1/hello.ts
+++ b/src/api/v1/hello.ts
@@ -4,7 +4,7 @@ import {
   ErrorResponse,
   ValidationErrorResponse,
 } from '../Response';
-import { HttpStatusCode } from './../../constants/HttpStatusCode';
+import { HttpStatusCode } from '@constants/HttpStatusCode';
 
 type Request = {
   name: string;

--- a/src/api/v1/hello.ts
+++ b/src/api/v1/hello.ts
@@ -5,6 +5,7 @@ import {
   ValidationErrorResponse,
 } from '../Response';
 import { HttpStatusCode } from '@constants/HttpStatusCode';
+import { valueOf } from '../utils/valueOf';
 
 type Request = {
   name: string;
@@ -13,9 +14,12 @@ type Request = {
 
 type SayHelloSuccessResponse = SuccessResponse<{ message: string }>;
 
-type ErrorCode = 'NotAllowedMessage';
+type errors = {
+  NotAllowedMessage: 'NotAllowedMessage';
+};
 
-type ErrorMessage = 'NotAllowedMessage';
+type ErrorCode = keyof errors;
+type ErrorMessage = valueOf<errors>;
 
 type SayHelloErrorResponse = ErrorResponse<ErrorCode, ErrorMessage>;
 

--- a/src/api/v1/hello.ts
+++ b/src/api/v1/hello.ts
@@ -14,12 +14,12 @@ type Request = {
 
 type SayHelloSuccessResponse = SuccessResponse<{ message: string }>;
 
-type errors = {
+export type Errors = {
   NotAllowedMessage: 'NotAllowedMessage';
 };
 
-type ErrorCode = keyof errors;
-type ErrorMessage = valueOf<errors>;
+type ErrorCode = keyof Errors;
+type ErrorMessage = valueOf<Errors>;
 
 type SayHelloErrorResponse = ErrorResponse<ErrorCode, ErrorMessage>;
 

--- a/src/api/v1/hello.ts
+++ b/src/api/v1/hello.ts
@@ -15,7 +15,7 @@ type Request = {
 export type SayHelloSuccessResponse = SuccessResponse<{ message: string }>;
 
 export type Errors = {
-  NotAllowedMessage: 'NotAllowedMessage';
+  notAllowedMessage: 'message is not allowed';
 };
 
 type ErrorCode = keyof Errors;
@@ -74,8 +74,8 @@ export const hello = (
     return {
       statusCode: HttpStatusCode.badRequest,
       body: {
-        code: 'NotAllowedMessage',
-        message: 'NotAllowedMessage',
+        code: 'notAllowedMessage',
+        message: 'message is not allowed',
       },
     };
   }

--- a/src/api/v1/hello.ts
+++ b/src/api/v1/hello.ts
@@ -4,6 +4,7 @@ import {
   ErrorResponse,
   ValidationErrorResponse,
 } from '../Response';
+import { HttpStatusCode } from './../../constants/HttpStatusCode';
 
 type Request = {
   name: string;
@@ -57,7 +58,7 @@ export const hello = (
     });
 
     return {
-      statusCode: 422,
+      statusCode: HttpStatusCode.unprocessableEntity,
       body: {
         message: 'Unprocessable Entity',
         validationErrors,
@@ -67,7 +68,7 @@ export const hello = (
 
   if (request.name === 'Error') {
     return {
-      statusCode: 400,
+      statusCode: HttpStatusCode.badRequest,
       body: {
         code: 'NotAllowedMessage',
         message: 'NotAllowedMessage',
@@ -76,7 +77,7 @@ export const hello = (
   }
 
   return {
-    statusCode: 200,
+    statusCode: HttpStatusCode.ok,
     body: {
       message: `Hello ${request.name}, welcome to the exciting Serverless world! Your Status is ${request.status}!`,
     },

--- a/src/api/v1/hello.ts
+++ b/src/api/v1/hello.ts
@@ -12,7 +12,7 @@ type Request = {
   status: number;
 };
 
-type SayHelloSuccessResponse = SuccessResponse<{ message: string }>;
+export type SayHelloSuccessResponse = SuccessResponse<{ message: string }>;
 
 export type Errors = {
   NotAllowedMessage: 'NotAllowedMessage';
@@ -21,7 +21,7 @@ export type Errors = {
 type ErrorCode = keyof Errors;
 type ErrorMessage = valueOf<Errors>;
 
-type SayHelloErrorResponse = ErrorResponse<ErrorCode, ErrorMessage>;
+export type SayHelloErrorResponse = ErrorResponse<ErrorCode, ErrorMessage>;
 
 const schema = {
   type: 'object',

--- a/src/constants/HttpStatusCode.ts
+++ b/src/constants/HttpStatusCode.ts
@@ -1,14 +1,17 @@
 // https://developer.mozilla.org/ja/docs/Web/HTTP/Status から必要なものを抜粋して定義
-export type HttpStatusCode =
-  | 200
-  | 201
-  | 202
-  | 204
-  | 400
-  | 401
-  | 403
-  | 404
-  | 408
-  | 422
-  | 500
-  | 503;
+export const HttpStatusCode = {
+  ok: 200,
+  created: 201,
+  accepted: 202,
+  noContent: 204,
+  badRequest: 400,
+  unauthorized: 401,
+  forbidden: 403,
+  notFound: 404,
+  requestTimeout: 408,
+  unprocessableEntity: 422,
+  internalServerError: 500,
+  serviceUnavailable: 503,
+} as const;
+
+export type HttpStatusCode = typeof HttpStatusCode[keyof typeof HttpStatusCode];


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/aws-serverless-node-api-boilerplate/issues/15

# Doneの定義
- https://github.com/nekochans/aws-serverless-node-api-boilerplate/issues/15 の完了の定義を満たしている事

# 変更点概要

HTTPステータスコードと各APIのエラーコード、エラーメッセージをunion型を使って定義するように改修。

APIのエラーコード、エラーメッセージに関しては、オリジナルのヘルパー型定義である `valueOf` を定義し解決しました。

またエラーメッセージやエラーコードの命名規則も若干修正してあります。

エラーメッセージ、エラーコードのリファクタリングなどは安全に行えるようになったと思います。