### PR TITLE
APIレスポンスの生成部分を共通化

### DIFF
--- a/src/api/response.ts
+++ b/src/api/response.ts
@@ -5,6 +5,16 @@ export type SuccessResponse<T> = {
   body: T;
 };
 
+export const createSuccessResponse = <T>(
+  statusCode: HttpStatusCode,
+  body: T,
+): SuccessResponse<T> => {
+  return {
+    statusCode,
+    body,
+  };
+};
+
 export type ErrorResponse<T, U> = {
   statusCode: HttpStatusCode;
   body: {

--- a/src/api/response.ts
+++ b/src/api/response.ts
@@ -23,6 +23,20 @@ export type ErrorResponse<T, U> = {
   };
 };
 
+export const createErrorResponse = <T, U>(params: {
+  statusCode: HttpStatusCode;
+  errorCode: T;
+  errorMessage: U;
+}): ErrorResponse<T, U> => {
+  return {
+    statusCode: params.statusCode,
+    body: {
+      code: params.errorCode,
+      message: params.errorMessage,
+    },
+  };
+};
+
 type ValidationErrorResponseMessage = 'Unprocessable Entity';
 
 export const validationErrorResponseMessage =

--- a/src/api/response.ts
+++ b/src/api/response.ts
@@ -5,13 +5,13 @@ export type SuccessResponse<T> = {
   body: T;
 };
 
-export const createSuccessResponse = <T>(
-  statusCode: HttpStatusCode,
-  body: T,
-): SuccessResponse<T> => {
+export const createSuccessResponse = <T>(params: {
+  statusCode: HttpStatusCode;
+  body: T;
+}): SuccessResponse<T> => {
   return {
-    statusCode,
-    body,
+    statusCode: params.statusCode,
+    body: params.body,
   };
 };
 

--- a/src/api/v1/addressSearch.ts
+++ b/src/api/v1/addressSearch.ts
@@ -3,6 +3,7 @@ import {
   ErrorResponse,
   ValidationErrorResponse,
   createSuccessResponse,
+  createErrorResponse,
 } from '../response';
 import { FetchAddressByPostalCode } from '../repositories/interfaces/address';
 import {
@@ -68,45 +69,39 @@ export const addressSearch = async (
     }
 
     if (request.postalCode === '1000000') {
-      return {
+      return createErrorResponse<ErrorCode, ErrorMessage>({
         statusCode: HttpStatusCode.badRequest,
-        body: {
-          code: 'notAllowedPostalCode',
-          message: 'not allowed to search by that postalCode',
-        },
-      };
+        errorCode: 'notAllowedPostalCode',
+        errorMessage: 'not allowed to search by that postalCode',
+      });
     }
 
     const address = await fetchAddressByPostalCode(request.postalCode);
 
     return createSuccessResponse<ResponseBody>(HttpStatusCode.ok, address);
   } catch (error) {
-    return createErrorResponse(error);
+    return createAddressSearchErrorResponse(error);
   }
 };
 
-const createErrorResponse = (
+const createAddressSearchErrorResponse = (
   error: FetchAddressByPostalCodeError,
 ): AddressSearchErrorResponse => {
   const errorMessage = error.message as FetchAddressByPostalCodeErrorMessage;
 
   switch (errorMessage) {
     case 'addressNotFoundError':
-      return {
+      return createErrorResponse<ErrorCode, ErrorMessage>({
         statusCode: HttpStatusCode.notFound,
-        body: {
-          code: 'notFoundAddress',
-          message: 'address is not found',
-        },
-      };
+        errorCode: 'notFoundAddress',
+        errorMessage: 'address is not found',
+      });
     case 'unexpectedError':
-      return {
+      return createErrorResponse<ErrorCode, ErrorMessage>({
         statusCode: HttpStatusCode.internalServerError,
-        body: {
-          code: 'unexpectedError',
-          message: 'unexpected error',
-        },
-      };
+        errorCode: 'unexpectedError',
+        errorMessage: 'unexpected error',
+      });
     default:
       return assertNever(errorMessage);
   }

--- a/src/api/v1/addressSearch.ts
+++ b/src/api/v1/addressSearch.ts
@@ -2,6 +2,7 @@ import {
   SuccessResponse,
   ErrorResponse,
   ValidationErrorResponse,
+  createSuccessResponse,
 } from '../response';
 import { FetchAddressByPostalCode } from '../repositories/interfaces/address';
 import {
@@ -78,10 +79,7 @@ export const addressSearch = async (
 
     const address = await fetchAddressByPostalCode(request.postalCode);
 
-    return {
-      statusCode: HttpStatusCode.ok,
-      body: address,
-    };
+    return createSuccessResponse<ResponseBody>(HttpStatusCode.ok, address);
   } catch (error) {
     return createErrorResponse(error);
   }

--- a/src/api/v1/addressSearch.ts
+++ b/src/api/v1/addressSearch.ts
@@ -78,7 +78,10 @@ export const addressSearch = async (
 
     const address = await fetchAddressByPostalCode(request.postalCode);
 
-    return createSuccessResponse<ResponseBody>(HttpStatusCode.ok, address);
+    return createSuccessResponse<ResponseBody>({
+      statusCode: HttpStatusCode.ok,
+      body: address,
+    });
   } catch (error) {
     return createAddressSearchErrorResponse(error);
   }

--- a/src/api/v1/createUser.ts
+++ b/src/api/v1/createUser.ts
@@ -4,7 +4,7 @@ import {
   SuccessResponse,
   ErrorResponse,
   ValidationErrorResponse,
-  createSuccessResponse,
+  createSuccessResponse, createErrorResponse,
 } from '../response';
 
 import { UserEntity } from '../domain/types/userEntity';
@@ -25,6 +25,7 @@ export type CreateUserSuccessResponse = SuccessResponse<ResponseBody>;
 
 type Errors = {
   emailAlreadyRegistered: 'email is already registered';
+  dbError: 'error in database',
 };
 
 type ErrorCode = keyof Errors;
@@ -95,22 +96,18 @@ export const createUser = async (
       error?.code === 'P2002' &&
       error?.meta?.target === 'uq_users_emails_02'
     ) {
-      return {
+      return createErrorResponse<ErrorCode, ErrorMessage>({
         statusCode: HttpStatusCode.badRequest,
-        body: {
-          code: 'emailAlreadyRegistered',
-          message: 'email is already registered',
-        },
-      };
+        errorCode: 'emailAlreadyRegistered',
+        errorMessage: 'email is already registered',
+      });
     }
 
-    return {
+    return createErrorResponse<ErrorCode, ErrorMessage>({
       statusCode: HttpStatusCode.internalServerError,
-      body: {
-        code: 'emailAlreadyRegistered',
-        message: 'email is already registered',
-      },
-    };
+      errorCode: 'dbError',
+      errorMessage: 'error in database',
+    });
   } finally {
     await prisma.$disconnect();
   }

--- a/src/api/v1/createUser.ts
+++ b/src/api/v1/createUser.ts
@@ -74,13 +74,11 @@ export const createUser = async (
     });
 
     if (user) {
-      return {
+      return createErrorResponse<ErrorCode, ErrorMessage>({
         statusCode: HttpStatusCode.badRequest,
-        body: {
-          code: 'emailAlreadyRegistered',
-          message: 'email is already registered',
-        },
-      };
+        errorCode: 'emailAlreadyRegistered',
+        errorMessage: 'email is already registered',
+      });
     }
 
     const newUser = await prisma.users.create(createUserParams(request));

--- a/src/api/v1/createUser.ts
+++ b/src/api/v1/createUser.ts
@@ -4,6 +4,7 @@ import {
   SuccessResponse,
   ErrorResponse,
   ValidationErrorResponse,
+  createSuccessResponse,
 } from '../response';
 
 import { UserEntity } from '../domain/types/userEntity';
@@ -84,12 +85,9 @@ export const createUser = async (
 
     const userEntity = await createUserEntity(prisma, newUser);
 
-    return {
-      statusCode: HttpStatusCode.created,
-      body: {
-        user: userEntity,
-      },
-    };
+    return createSuccessResponse<ResponseBody>(HttpStatusCode.created, {
+      user: userEntity,
+    });
   } catch (error) {
     // Prismaのエラーオブジェクトは下記のような仕様、これを元に判定する事は出来る
     // https://www.prisma.io/docs/reference/api-reference/error-reference

--- a/src/api/v1/createUser.ts
+++ b/src/api/v1/createUser.ts
@@ -4,7 +4,8 @@ import {
   SuccessResponse,
   ErrorResponse,
   ValidationErrorResponse,
-  createSuccessResponse, createErrorResponse,
+  createSuccessResponse,
+  createErrorResponse,
 } from '../response';
 
 import { UserEntity } from '../domain/types/userEntity';
@@ -25,7 +26,7 @@ export type CreateUserSuccessResponse = SuccessResponse<ResponseBody>;
 
 type Errors = {
   emailAlreadyRegistered: 'email is already registered';
-  dbError: 'error in database',
+  dbError: 'error in database';
 };
 
 type ErrorCode = keyof Errors;
@@ -86,8 +87,9 @@ export const createUser = async (
 
     const userEntity = await createUserEntity(prisma, newUser);
 
-    return createSuccessResponse<ResponseBody>(HttpStatusCode.created, {
-      user: userEntity,
+    return createSuccessResponse<ResponseBody>({
+      statusCode: HttpStatusCode.created,
+      body: { user: userEntity },
     });
   } catch (error) {
     // Prismaのエラーオブジェクトは下記のような仕様、これを元に判定する事は出来る

--- a/src/api/v1/hello.ts
+++ b/src/api/v1/hello.ts
@@ -2,6 +2,7 @@ import {
   SuccessResponse,
   ErrorResponse,
   ValidationErrorResponse,
+  createSuccessResponse,
 } from '../response';
 import { HttpStatusCode } from '@constants/httpStatusCode';
 import { valueOf } from '../utils/valueOf';
@@ -12,7 +13,11 @@ type Request = {
   status: number;
 };
 
-export type HelloSuccessResponse = SuccessResponse<{ message: string }>;
+type ResponseBody = {
+  message: string;
+};
+
+export type HelloSuccessResponse = SuccessResponse<ResponseBody>;
 
 export type Errors = {
   notAllowedMessage: 'message is not allowed';
@@ -62,12 +67,9 @@ export const hello = (
     };
   }
 
-  return {
-    statusCode: HttpStatusCode.ok,
-    body: {
-      message: `Hello ${request.name}, welcome to the exciting Serverless world! Your Status is ${request.status}!`,
-    },
-  };
+  return createSuccessResponse<ResponseBody>(HttpStatusCode.ok, {
+    message: `Hello ${request.name}, welcome to the exciting Serverless world! Your Status is ${request.status}!`,
+  });
 };
 
 export default hello;

--- a/src/api/v1/hello.ts
+++ b/src/api/v1/hello.ts
@@ -2,7 +2,8 @@ import {
   SuccessResponse,
   ErrorResponse,
   ValidationErrorResponse,
-  createSuccessResponse, createErrorResponse,
+  createSuccessResponse,
+  createErrorResponse,
 } from '../response';
 import { HttpStatusCode } from '@constants/httpStatusCode';
 import { valueOf } from '../utils/valueOf';
@@ -65,8 +66,11 @@ export const hello = (
     });
   }
 
-  return createSuccessResponse<ResponseBody>(HttpStatusCode.ok, {
-    message: `Hello ${request.name}, welcome to the exciting Serverless world! Your Status is ${request.status}!`,
+  return createSuccessResponse<ResponseBody>({
+    statusCode: HttpStatusCode.ok,
+    body: {
+      message: `Hello ${request.name}, welcome to the exciting Serverless world! Your Status is ${request.status}!`,
+    },
   });
 };
 

--- a/src/api/v1/hello.ts
+++ b/src/api/v1/hello.ts
@@ -2,7 +2,7 @@ import {
   SuccessResponse,
   ErrorResponse,
   ValidationErrorResponse,
-  createSuccessResponse,
+  createSuccessResponse, createErrorResponse,
 } from '../response';
 import { HttpStatusCode } from '@constants/httpStatusCode';
 import { valueOf } from '../utils/valueOf';
@@ -58,13 +58,11 @@ export const hello = (
   }
 
   if (request.name === 'Error') {
-    return {
+    return createErrorResponse<ErrorCode, ErrorMessage>({
       statusCode: HttpStatusCode.badRequest,
-      body: {
-        code: 'notAllowedMessage',
-        message: 'message is not allowed',
-      },
-    };
+      errorCode: 'notAllowedMessage',
+      errorMessage: 'message is not allowed',
+    });
   }
 
   return createSuccessResponse<ResponseBody>(HttpStatusCode.ok, {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/aws-serverless-node-api-boilerplate/issues/11

# Doneの定義
- APIのレスポンス生成が別の関数に分離されている事

# 変更点概要
`createSuccessResponse`, `createErrorResponse` を定義しレスポンスの生成はそれを利用するように変更。

テストコードに関しては、期待値を見やすくする為にそのままにしてある。