### PR TITLE
helloWithPathのレスポンスBody生成部分を別の関数に分離

### DIFF
--- a/serverless.ts
+++ b/serverless.ts
@@ -1,5 +1,5 @@
 import type { AWS } from '@serverless/typescript';
-import {hello, helloWithPath, addressSearch, createUser} from '@functions/index';
+import { hello, helloWithPath, addressSearch, createUser } from '@functions/index';
 
 const serverlessConfiguration: AWS = {
   service: 'serverless-node-api',

--- a/src/api/v1/__tests__/helloWithPath.spec.ts
+++ b/src/api/v1/__tests__/helloWithPath.spec.ts
@@ -1,0 +1,57 @@
+import helloWithPath, {
+  HelloWithPathErrorResponse,
+  HelloWithPathSuccessResponse,
+} from '../helloWithPath';
+import { HttpStatusCode } from '@constants/httpStatusCode';
+import { validationErrorResponseMessage } from '../../response';
+
+describe('helloWithPath', () => {
+  it('should return a success message', () => {
+    const request = {
+      helloId: 'MokoCat1',
+    };
+
+    const expected: HelloWithPathSuccessResponse = {
+      statusCode: HttpStatusCode.ok,
+      body: {
+        message: `HelloWithPath ${request.helloId}, welcome to the exciting Serverless world!`,
+      },
+    };
+
+    expect(helloWithPath(request)).toStrictEqual(expected);
+  });
+
+  it('should return a Error', () => {
+    const request = {
+      helloId: 'Error',
+    };
+
+    const expected: HelloWithPathErrorResponse = {
+      statusCode: HttpStatusCode.badRequest,
+      body: {
+        code: 'notAllowedHelloId',
+        message: 'helloId is not allowed',
+      },
+    };
+
+    expect(helloWithPath(request)).toStrictEqual(expected);
+  });
+
+  it('should return a validation error', () => {
+    const request = {
+      helloId: 'MokoCatMokoCat',
+    };
+
+    const expected = {
+      statusCode: HttpStatusCode.unprocessableEntity,
+      body: {
+        message: validationErrorResponseMessage(),
+        validationErrors: [
+          { key: 'helloId', reason: 'must NOT have more than 8 characters' },
+        ],
+      },
+    };
+
+    expect(helloWithPath(request)).toStrictEqual(expected);
+  });
+});

--- a/src/api/v1/helloWithPath.ts
+++ b/src/api/v1/helloWithPath.ts
@@ -1,0 +1,74 @@
+import {
+  SuccessResponse,
+  ErrorResponse,
+  ValidationErrorResponse,
+  createSuccessResponse,
+  createErrorResponse,
+} from '../response';
+import { HttpStatusCode } from '@constants/httpStatusCode';
+import { valueOf } from '../utils/valueOf';
+import validate from '../validate';
+
+type Request = {
+  helloId: string;
+};
+
+type ResponseBody = {
+  message: string;
+};
+
+export type HelloWithPathSuccessResponse = SuccessResponse<ResponseBody>;
+
+export type Errors = {
+  notAllowedHelloId: 'helloId is not allowed';
+};
+
+type ErrorCode = keyof Errors;
+type ErrorMessage = valueOf<Errors>;
+
+export type HelloWithPathErrorResponse = ErrorResponse<ErrorCode, ErrorMessage>;
+
+const schema = {
+  type: 'object',
+  properties: {
+    helloId: {
+      type: 'string',
+      minLength: 4,
+      maxLength: 8,
+    },
+  },
+  required: ['helloId'],
+  additionalProperties: false,
+};
+
+export const helloWithPath = (
+  request: Request,
+):
+  | HelloWithPathSuccessResponse
+  | HelloWithPathErrorResponse
+  | ValidationErrorResponse => {
+  const validateResult = validate<Request>(schema, request);
+  if (
+    validateResult.isError === true &&
+    validateResult.validationErrorResponse
+  ) {
+    return validateResult.validationErrorResponse;
+  }
+
+  if (request.helloId === 'Error') {
+    return createErrorResponse<ErrorCode, ErrorMessage>({
+      statusCode: HttpStatusCode.badRequest,
+      errorCode: 'notAllowedHelloId',
+      errorMessage: 'helloId is not allowed',
+    });
+  }
+
+  return createSuccessResponse<ResponseBody>({
+    statusCode: HttpStatusCode.ok,
+    body: {
+      message: `HelloWithPath ${request.helloId}, welcome to the exciting Serverless world!`,
+    },
+  });
+};
+
+export default helloWithPath;

--- a/src/functions/hello/handler.ts
+++ b/src/functions/hello/handler.ts
@@ -16,9 +16,11 @@ const helloHandler: ValidatedEventAPIGatewayProxyEvent<
   typeof defaultPathParams,
   typeof defaultQueryParams
 > = async (event) => {
-  const apiRes = hello(event.body);
+  const request = event.body;
 
-  return formatJsonResponse(apiRes.statusCode, apiRes.body);
+  const response = hello(request);
+
+  return formatJsonResponse(response.statusCode, response.body);
 };
 
 export const main = middyfy(helloHandler);

--- a/src/functions/helloWithPath/handler.ts
+++ b/src/functions/helloWithPath/handler.ts
@@ -9,6 +9,7 @@ import defaultRequestBody from '@constants/defaultRequestBody';
 
 import pathParams from './pathParams';
 import queryParams from './queryParams';
+import helloWithPath from '../../api/v1/helloWithPath';
 
 const helloWithPathHandler: ValidatedEventAPIGatewayProxyEvent<
   typeof defaultRequestHeader,
@@ -16,12 +17,11 @@ const helloWithPathHandler: ValidatedEventAPIGatewayProxyEvent<
   typeof pathParams,
   typeof queryParams
 > = async (event) => {
-  const responseBody = {
-    message: `HelloWithPath ${event.pathParameters.helloId}, welcome to the exciting Serverless world!`,
-    event,
-  };
+  const request = event.pathParameters;
 
-  return formatJsonResponse(200, responseBody);
+  const response = helloWithPath(request);
+
+  return formatJsonResponse(response.statusCode, response.body);
 };
 
 export const main = middyfy(helloWithPathHandler);


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/aws-serverless-node-api-boilerplate/issues/13

# Doneの定義
- helloWithPathのレスポンス生成部分が他のAPIと同様に別の関数に分離されている事

# 変更点概要
helloWithPathを定義しレスポンスの生成部分を分離しました。

他、軽微なリファクタリングを実施しました。