### PR TITLE
JSONスキーマの定義部分を共通化

### DIFF
--- a/src/api/domain/types/schemas/addressSchema.ts
+++ b/src/api/domain/types/schemas/addressSchema.ts
@@ -1,0 +1,9 @@
+export const AddressSchema = {
+  postalCode: {
+    type: 'string',
+    minLength: 7,
+    maxLength: 7,
+  },
+} as const;
+
+export type AddressSchema = typeof AddressSchema[keyof typeof AddressSchema];

--- a/src/api/domain/types/schemas/helloSchema.ts
+++ b/src/api/domain/types/schemas/helloSchema.ts
@@ -1,0 +1,19 @@
+export const HelloSchema = {
+  name: {
+    type: 'string',
+    minLength: 4,
+    maxLength: 8,
+  },
+  status: {
+    type: 'number',
+    minimum: 1,
+    maximum: 1,
+  },
+  helloId: {
+    type: 'string',
+    minLength: 4,
+    maxLength: 8,
+  },
+} as const;
+
+export type HelloSchema = typeof HelloSchema[keyof typeof HelloSchema];

--- a/src/api/domain/types/schemas/userSchema.ts
+++ b/src/api/domain/types/schemas/userSchema.ts
@@ -1,0 +1,14 @@
+export const UserSchema = {
+  email: {
+    type: 'string',
+    format: 'email',
+    maxLength: 254,
+  },
+  phoneNumber: {
+    type: 'string',
+    minLength: 10,
+    maxLength: 11,
+  },
+} as const;
+
+export type UserSchema = typeof UserSchema[keyof typeof UserSchema];

--- a/src/api/v1/addressSearch.ts
+++ b/src/api/v1/addressSearch.ts
@@ -14,6 +14,7 @@ import assertNever from '../utils/assertNever';
 import { HttpStatusCode } from '@constants/httpStatusCode';
 import { valueOf } from '../utils/valueOf';
 import validate from '../validate';
+import { AddressSchema } from '../domain/types/schemas/addressSchema';
 
 type Request = {
   postalCode: string;
@@ -41,11 +42,7 @@ export type AddressSearchErrorResponse = ErrorResponse<ErrorCode, ErrorMessage>;
 const schema = {
   type: 'object',
   properties: {
-    postalCode: {
-      type: 'string',
-      minLength: 7,
-      maxLength: 7,
-    },
+    postalCode: AddressSchema.postalCode,
   },
   required: ['postalCode'],
   additionalProperties: false,

--- a/src/api/v1/createUser.ts
+++ b/src/api/v1/createUser.ts
@@ -12,6 +12,7 @@ import { UserEntity } from '../domain/types/userEntity';
 import { HttpStatusCode } from '@constants/httpStatusCode';
 import { valueOf } from '../utils/valueOf';
 import validate from '../validate';
+import { UserSchema } from '../domain/types/schemas/userSchema';
 
 type Request = {
   email: string;
@@ -37,16 +38,8 @@ export type CreateUserErrorResponse = ErrorResponse<ErrorCode, ErrorMessage>;
 const schema = {
   type: 'object',
   properties: {
-    email: {
-      type: 'string',
-      format: 'email',
-      maxLength: 254,
-    },
-    phoneNumber: {
-      type: 'string',
-      minLength: 10,
-      maxLength: 11,
-    },
+    email: UserSchema.email,
+    phoneNumber: UserSchema.phoneNumber,
   },
   required: ['email'],
   additionalProperties: false,

--- a/src/api/v1/hello.ts
+++ b/src/api/v1/hello.ts
@@ -8,6 +8,7 @@ import {
 import { HttpStatusCode } from '@constants/httpStatusCode';
 import { valueOf } from '../utils/valueOf';
 import validate from '../validate';
+import { HelloSchema } from '../domain/types/schemas/helloSchema';
 
 type Request = {
   name: string;
@@ -32,16 +33,8 @@ export type HelloErrorResponse = ErrorResponse<ErrorCode, ErrorMessage>;
 const schema = {
   type: 'object',
   properties: {
-    name: {
-      type: 'string',
-      minLength: 4,
-      maxLength: 8,
-    },
-    status: {
-      type: 'number',
-      minimum: 1,
-      maximum: 1,
-    },
+    name: HelloSchema.name,
+    status: HelloSchema.status,
   },
   required: ['name', 'status'],
   additionalProperties: false,

--- a/src/api/v1/helloWithPath.ts
+++ b/src/api/v1/helloWithPath.ts
@@ -8,6 +8,7 @@ import {
 import { HttpStatusCode } from '@constants/httpStatusCode';
 import { valueOf } from '../utils/valueOf';
 import validate from '../validate';
+import { HelloSchema } from '../domain/types/schemas/helloSchema';
 
 type Request = {
   helloId: string;
@@ -31,11 +32,7 @@ export type HelloWithPathErrorResponse = ErrorResponse<ErrorCode, ErrorMessage>;
 const schema = {
   type: 'object',
   properties: {
-    helloId: {
-      type: 'string',
-      minLength: 4,
-      maxLength: 8,
-    },
+    helloId: HelloSchema.helloId,
   },
   required: ['helloId'],
   additionalProperties: false,

--- a/src/functions/addressSearch/pathParams.ts
+++ b/src/functions/addressSearch/pathParams.ts
@@ -1,11 +1,9 @@
+import { AddressSchema } from '../../api/domain/types/schemas/addressSchema';
+
 export default {
   type: 'object',
   properties: {
-    postalCode: {
-      type: 'string',
-      minLength: 7,
-      maxLength: 7,
-    },
+    postalCode: AddressSchema.postalCode,
   },
   required: ['postalCode'],
 } as const;

--- a/src/functions/createUser/requestBody.ts
+++ b/src/functions/createUser/requestBody.ts
@@ -1,16 +1,10 @@
+import { UserSchema } from '../../api/domain/types/schemas/userSchema';
+
 export default {
   type: 'object',
   properties: {
-    email: {
-      type: 'string',
-      format: 'email',
-      maxLength: 254,
-    },
-    phoneNumber: {
-      type: 'string',
-      minLength: 10,
-      maxLength: 11,
-    },
+    email: UserSchema.email,
+    phoneNumber: UserSchema.phoneNumber,
   },
   required: ['email'],
 } as const;

--- a/src/functions/hello/requestBody.ts
+++ b/src/functions/hello/requestBody.ts
@@ -1,16 +1,10 @@
+import { HelloSchema } from '../../api/domain/types/schemas/helloSchema';
+
 export default {
   type: 'object',
   properties: {
-    name: {
-      type: 'string',
-      minLength: 4,
-      maxLength: 8,
-    },
-    status: {
-      type: 'number',
-      minimum: 1,
-      maximum: 1,
-    },
+    name: HelloSchema.name,
+    status: HelloSchema.status,
   },
   required: ['name', 'status'],
 } as const;

--- a/src/functions/helloWithPath/pathParams.ts
+++ b/src/functions/helloWithPath/pathParams.ts
@@ -1,7 +1,9 @@
+import { HelloSchema } from '../../api/domain/types/schemas/helloSchema';
+
 export default {
   type: 'object',
   properties: {
-    helloId: { type: 'string' },
+    helloId: HelloSchema.helloId,
   },
   required: ['helloId'],
 } as const;


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/aws-serverless-node-api-boilerplate/issues/10

# Doneの定義
- JSONスキーマの定義部分が共通処理として定義されている事

# 変更点概要
`src/api/domain/types/schemas/` JSONスキーマ用の定義を追加しました。

JSONスキーマには `properties` や `required` などの定義はあえて共通化していません。

複数のAPIで同名のパラメータを利用する可能性があるので、この部分を共通化してしまうと重複して定義してしまう可能性が出てくる為です。