### PR TITLE
createUserのDB接続部分をRepositoryパターンに置き換え

### DIFF
--- a/src/api/repositories/errors/createNewUserError.ts
+++ b/src/api/repositories/errors/createNewUserError.ts
@@ -4,6 +4,7 @@ export class CreateNewUserError extends ExtensibleCustomError {}
 
 export const CreateNewUserErrorMessage = {
   emailAlreadyRegisteredError: 'emailAlreadyRegisteredError',
+  unexpectedError: 'unexpectedError',
 } as const;
 
 export type CreateNewUserErrorMessage =

--- a/src/api/repositories/errors/createNewUserError.ts
+++ b/src/api/repositories/errors/createNewUserError.ts
@@ -1,0 +1,10 @@
+import ExtensibleCustomError from 'extensible-custom-error';
+
+export class CreateNewUserError extends ExtensibleCustomError {}
+
+export const CreateNewUserErrorMessage = {
+  emailAlreadyRegisteredError: 'emailAlreadyRegisteredError',
+} as const;
+
+export type CreateNewUserErrorMessage =
+  typeof CreateNewUserErrorMessage[keyof typeof CreateNewUserErrorMessage];

--- a/src/api/repositories/implements/prisma/user.ts
+++ b/src/api/repositories/implements/prisma/user.ts
@@ -29,9 +29,9 @@ export const createNewUser: CreateNewUser<PrismaClient> = async (
       };
     }
 
-    const newUser = await datastoreClient.users.create(
-      createUserParams({ email, phoneNumber }),
-    );
+    const [newUser] = await datastoreClient.$transaction([
+      datastoreClient.users.create(createUserParams({ email, phoneNumber })),
+    ]);
 
     const userEntity = await createUserEntity(datastoreClient, newUser);
 

--- a/src/api/repositories/implements/prisma/user.ts
+++ b/src/api/repositories/implements/prisma/user.ts
@@ -1,0 +1,62 @@
+import { PrismaClient, users } from '@prisma/client';
+import { UserEntity } from '../../../../domain/types/userEntity';
+import { CreateNewUser, CreateNewUserParams } from '../../../interfaces/user';
+
+export const createNewUser: CreateNewUser<PrismaClient> = async (
+  datastoreClient,
+  { email, phoneNumber },
+): Promise<UserEntity> => {
+  const newUser = await datastoreClient.users.create(
+    createUserParams({ email, phoneNumber }),
+  );
+
+  return await createUserEntity(datastoreClient, newUser);
+};
+
+const createUserParams = (createNewUserParams: CreateNewUserParams) => {
+  const params = {
+    data: {
+      users_emails: {
+        create: { email: createNewUserParams.email },
+      },
+    },
+  };
+
+  if (createNewUserParams.phoneNumber !== undefined) {
+    params.data['users_phone_numbers'] = {
+      create: [{ phone_number: createNewUserParams.phoneNumber }],
+    };
+  }
+
+  return params;
+};
+
+const createUserEntity = async (prisma: PrismaClient, newUser: users) => {
+  const responseData = await prisma.users.findUnique({
+    where: {
+      id: newUser.id,
+    },
+    include: {
+      users_emails: true,
+      users_phone_numbers: true,
+    },
+  });
+
+  const userEntity = {
+    id: responseData.id,
+    email: {
+      id: responseData.users_emails.id,
+      email: responseData.users_emails.email,
+    },
+  };
+
+  if (responseData.users_phone_numbers.length !== 0) {
+    userEntity['phoneNumbers'] = responseData.users_phone_numbers.map(
+      (value) => {
+        return { id: value.id, phoneNumber: value.phone_number };
+      },
+    );
+  }
+
+  return userEntity;
+};

--- a/src/api/repositories/implements/prisma/user.ts
+++ b/src/api/repositories/implements/prisma/user.ts
@@ -14,20 +14,20 @@ export const createNewUser: CreateNewUser<PrismaClient> = async (
   { email, phoneNumber },
 ): Promise<CreateNewUserResponse> => {
   try {
-    // const user = await datastoreClient.users_emails.findFirst({
-    //   where: {
-    //     email: email,
-    //   },
-    // });
-    //
-    // if (user) {
-    //   return {
-    //     isSuccessful: false,
-    //     error: new CreateNewUserError(
-    //       CreateNewUserErrorMessage.emailAlreadyRegisteredError,
-    //     ),
-    //   };
-    // }
+    const user = await datastoreClient.users_emails.findFirst({
+      where: {
+        email: email,
+      },
+    });
+
+    if (user) {
+      return {
+        isSuccessful: false,
+        error: new CreateNewUserError(
+          CreateNewUserErrorMessage.emailAlreadyRegisteredError,
+        ),
+      };
+    }
 
     const newUser = await datastoreClient.users.create(
       createUserParams({ email, phoneNumber }),

--- a/src/api/repositories/interfaces/user.ts
+++ b/src/api/repositories/interfaces/user.ts
@@ -1,0 +1,18 @@
+import { UserEntity } from '../../domain/types/userEntity';
+import { CreateNewUserError } from '../errors/createNewUserError';
+
+export type CreateNewUserParams = {
+  email: string;
+  phoneNumber?: string;
+};
+
+export type CreateNewUserResponse = {
+  isSuccessful: boolean;
+  userEntity?: UserEntity;
+  error?: CreateNewUserError;
+};
+
+export type CreateNewUser<T> = (
+  datastoreClient: T,
+  params: CreateNewUserParams,
+) => Promise<CreateNewUserResponse>;

--- a/src/api/v1/createUser.ts
+++ b/src/api/v1/createUser.ts
@@ -78,6 +78,12 @@ export const createUser = async (
             errorCode: 'emailAlreadyRegistered',
             errorMessage: 'email is already registered',
           });
+        case 'unexpectedError':
+          return createErrorResponse<ErrorCode, ErrorMessage>({
+            statusCode: HttpStatusCode.internalServerError,
+            errorCode: 'dbError',
+            errorMessage: 'error in database',
+          });
         default:
           assertNever(errorMessage);
       }
@@ -88,20 +94,6 @@ export const createUser = async (
       body: { user: createNewUserResponse.userEntity },
     });
   } catch (error) {
-    // TODO このブロックの処理は src/api/repositories/implements/prisma/user.ts に移動させる
-    // Prismaのエラーオブジェクトは下記のような仕様、これを元に判定する事は出来る
-    // https://www.prisma.io/docs/reference/api-reference/error-reference
-    if (
-      error?.code === 'P2002' &&
-      error?.meta?.target === 'uq_users_emails_02'
-    ) {
-      return createErrorResponse<ErrorCode, ErrorMessage>({
-        statusCode: HttpStatusCode.badRequest,
-        errorCode: 'emailAlreadyRegistered',
-        errorMessage: 'email is already registered',
-      });
-    }
-
     return createErrorResponse<ErrorCode, ErrorMessage>({
       statusCode: HttpStatusCode.internalServerError,
       errorCode: 'dbError',

--- a/src/functions/createUser/handler.ts
+++ b/src/functions/createUser/handler.ts
@@ -26,8 +26,6 @@ const createUserHandler: ValidatedEventAPIGatewayProxyEvent<
 
   const response = await createUser(request, prisma);
 
-  await prisma.$disconnect();
-
   return formatJsonResponse(response.statusCode, response.body);
 };
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/aws-serverless-node-api-boilerplate/issues/26

# Doneの定義
- https://github.com/nekochans/aws-serverless-node-api-boilerplate/issues/26 の完了の定義を満たしている事

# 変更点概要
`CreateNewUser` をRepositoryパターンを使って作成。

現時点では `src/api/v1/createUser.ts` 内で `PrismaClient` に依存しているのであまり意味はないかも。

もっと良い設計が思いついたら、変更する。