### PR TITLE
任意のHTTPヘッダーを返せるように改修

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,13 +28,15 @@
     "ajv-formats": "^2.1.0",
     "axios": "^0.21.1",
     "extensible-custom-error": "^0.0.7",
-    "source-map-support": "^0.5.19"
+    "source-map-support": "^0.5.19",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@serverless/typescript": "^2.38.0",
     "@types/aws-lambda": "^8.10.76",
     "@types/jest": "^26.0.23",
     "@types/node": "^15.0.1",
+    "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
     "axios-mock-adapter": "^1.19.0",

--- a/src/api/__tests__/request.spec.ts
+++ b/src/api/__tests__/request.spec.ts
@@ -1,0 +1,29 @@
+import { createApiRequest } from '../request';
+
+describe('request', () => {
+  it('should return a merged request object', () => {
+    const headers = {
+      'content-type': 'application/json',
+      'x-request-id': 'aaaaaaaa-bbbbbbbbb-123-ddddddddddddd',
+    };
+
+    type Result = {
+      id: number;
+      name: string;
+      'x-request-id': string;
+    };
+
+    const pathParams = { id: 1 };
+    const bodyParams = { name: 'neko' };
+
+    const expected: Result = {
+      id: pathParams.id,
+      name: bodyParams.name,
+      'x-request-id': headers['x-request-id'],
+    };
+
+    const result = createApiRequest<Result>(headers, pathParams, bodyParams);
+
+    expect(result).toStrictEqual(expected);
+  });
+});

--- a/src/api/domain/types/schemas/requestSchema.ts
+++ b/src/api/domain/types/schemas/requestSchema.ts
@@ -1,0 +1,9 @@
+export const RequestSchema = {
+  'x-request-id': {
+    type: 'string',
+    minLength: 36,
+    maxLength: 36,
+  },
+} as const;
+
+export type RequestSchema = typeof RequestSchema[keyof typeof RequestSchema];

--- a/src/api/request.ts
+++ b/src/api/request.ts
@@ -1,3 +1,30 @@
 export type DefaultApiRequest = {
   'x-request-id'?: string;
 };
+
+export type RequestParams = {
+  [header: string]: boolean | number | string | unknown;
+};
+
+export const createApiRequest = <T>(
+  requestHeaders: RequestParams,
+  ...requestParams: RequestParams[]
+): T => {
+  // letを使わない、もっと良い書き方があれば修正する
+  let mergedParams = {};
+  for (const params of requestParams) {
+    mergedParams = { ...mergedParams, ...params };
+  }
+
+  const mergedRequest = Object.prototype.hasOwnProperty.call(
+    requestHeaders,
+    'x-request-id',
+  )
+    ? {
+        ...mergedParams,
+        ...{ 'x-request-id': requestHeaders['x-request-id'] },
+      }
+    : { ...mergedParams };
+
+  return mergedRequest as T;
+};

--- a/src/api/request.ts
+++ b/src/api/request.ts
@@ -1,0 +1,3 @@
+export type DefaultApiRequest = {
+  'x-request-id'?: string;
+};

--- a/src/api/response.ts
+++ b/src/api/response.ts
@@ -1,17 +1,39 @@
 import { HttpStatusCode } from '@constants/httpStatusCode';
+import { v4 as uuidv4 } from 'uuid';
+
+export type ResponseHeaders = {
+  [header: string]: boolean | number | string;
+};
+
+export type DefaultResponseHeaders = {
+  'content-type': 'application/json';
+  'x-request-id': string;
+};
+
+export const createDefaultResponseHeaders = (
+  requestId?: string,
+): DefaultResponseHeaders => {
+  return {
+    'content-type': 'application/json',
+    'x-request-id': requestId ? requestId : uuidv4(),
+  };
+};
 
 export type SuccessResponse<T> = {
   statusCode: HttpStatusCode;
   body: T;
+  headers: ResponseHeaders;
 };
 
 export const createSuccessResponse = <T>(params: {
   statusCode: HttpStatusCode;
   body: T;
+  headers: ResponseHeaders;
 }): SuccessResponse<T> => {
   return {
     statusCode: params.statusCode,
     body: params.body,
+    headers: params.headers,
   };
 };
 
@@ -21,12 +43,14 @@ export type ErrorResponse<T, U> = {
     code: T;
     message: U;
   };
+  headers: ResponseHeaders;
 };
 
 export const createErrorResponse = <T, U>(params: {
   statusCode: HttpStatusCode;
   errorCode: T;
   errorMessage: U;
+  headers: ResponseHeaders;
 }): ErrorResponse<T, U> => {
   return {
     statusCode: params.statusCode,
@@ -34,6 +58,7 @@ export const createErrorResponse = <T, U>(params: {
       code: params.errorCode,
       message: params.errorMessage,
     },
+    headers: params.headers,
   };
 };
 
@@ -50,4 +75,5 @@ export type ValidationErrorResponse = {
     message: ValidationErrorResponseMessage;
     validationErrors: { key: string; reason: string }[];
   };
+  headers: ResponseHeaders;
 };

--- a/src/api/v1/__tests__/addressSearch.spec.ts
+++ b/src/api/v1/__tests__/addressSearch.spec.ts
@@ -13,10 +13,24 @@ import {
   validationErrorResponseMessage,
 } from '../../response';
 import { HttpStatusCode } from '@constants/httpStatusCode';
+import * as response from '../../response';
 
 describe('addressSearch', () => {
+  let responseSpy;
+  const fakeRequestId = 'aaaaaaaa-bbbbbbbbb-123-ddddddddddddd';
+
+  beforeEach(() => {
+    responseSpy = jest
+      .spyOn(response, 'createDefaultResponseHeaders')
+      .mockReturnValue({
+        'content-type': 'application/json',
+        'x-request-id': fakeRequestId,
+      });
+  });
+
   afterEach(() => {
     axiosMock.restore();
+    responseSpy.mockRestore();
   });
 
   it('should return a address', async () => {
@@ -52,6 +66,10 @@ describe('addressSearch', () => {
         region: '東京都',
         locality: '新宿区',
       },
+      headers: {
+        'content-type': 'application/json',
+        'x-request-id': fakeRequestId,
+      },
     };
 
     const actual = await addressSearch(request, fetchAddressByPostalCode);
@@ -69,6 +87,10 @@ describe('addressSearch', () => {
       body: {
         code: 'notAllowedPostalCode',
         message: 'not allowed to search by that postalCode',
+      },
+      headers: {
+        'content-type': 'application/json',
+        'x-request-id': fakeRequestId,
       },
     };
 
@@ -98,6 +120,10 @@ describe('addressSearch', () => {
         code: 'notFoundAddress',
         message: 'address is not found',
       },
+      headers: {
+        'content-type': 'application/json',
+        'x-request-id': fakeRequestId,
+      },
     };
 
     const actual = await addressSearch(request, fetchAddressByPostalCode);
@@ -117,6 +143,10 @@ describe('addressSearch', () => {
         validationErrors: [
           { key: 'postalCode', reason: 'must NOT have more than 7 characters' },
         ],
+      },
+      headers: {
+        'content-type': 'application/json',
+        'x-request-id': fakeRequestId,
       },
     };
 

--- a/src/api/v1/__tests__/addressSearch.spec.ts
+++ b/src/api/v1/__tests__/addressSearch.spec.ts
@@ -133,6 +133,7 @@ describe('addressSearch', () => {
 
   it('should return a validation error', async () => {
     const request = {
+      'x-request-id': 'aaaaaaaa-bbbbbbbbb-123-dddddddddddd',
       postalCode: '12345678',
     };
 
@@ -142,6 +143,10 @@ describe('addressSearch', () => {
         message: validationErrorResponseMessage(),
         validationErrors: [
           { key: 'postalCode', reason: 'must NOT have more than 7 characters' },
+          {
+            key: 'x-request-id',
+            reason: 'must NOT have fewer than 36 characters',
+          },
         ],
       },
       headers: {

--- a/src/api/v1/__tests__/createUser.spec.ts
+++ b/src/api/v1/__tests__/createUser.spec.ts
@@ -127,6 +127,7 @@ describe('createUser', () => {
 
   it('should return a validation error', async () => {
     const request = {
+      'x-request-id': 'aaaaaaaa-bbbbbbbbb-123-dddddddddddd',
       email: '12345678',
     };
 
@@ -136,6 +137,10 @@ describe('createUser', () => {
         message: validationErrorResponseMessage(),
         validationErrors: [
           { key: 'email', reason: 'must match format "email"' },
+          {
+            key: 'x-request-id',
+            reason: 'must NOT have fewer than 36 characters',
+          },
         ],
       },
       headers: {

--- a/src/api/v1/__tests__/createUser.spec.ts
+++ b/src/api/v1/__tests__/createUser.spec.ts
@@ -8,11 +8,20 @@ import {
   validationErrorResponseMessage,
 } from '../../response';
 import { HttpStatusCode } from '@constants/httpStatusCode';
+import * as response from '../../response';
 
 describe('createUser', () => {
   let prisma: PrismaClient;
+  let responseSpy;
+  const fakeRequestId = 'aaaaaaaa-bbbbbbbbb-123-ddddddddddddd';
 
   beforeEach(async () => {
+    responseSpy = jest
+      .spyOn(response, 'createDefaultResponseHeaders')
+      .mockReturnValue({
+        'content-type': 'application/json',
+        'x-request-id': fakeRequestId,
+      });
     prisma = new PrismaClient();
 
     try {
@@ -27,6 +36,10 @@ describe('createUser', () => {
     } finally {
       await prisma.$disconnect();
     }
+  });
+
+  afterEach(() => {
+    responseSpy.mockRestore();
   });
 
   it('will create a new user, Only the required parameters are specified', async () => {
@@ -45,11 +58,16 @@ describe('createUser', () => {
           },
         },
       },
+      headers: {
+        'content-type': 'application/json',
+        'x-request-id': fakeRequestId,
+      },
     };
 
     const actual = await createUser(request, prisma);
 
     expect(actual).toStrictEqual(expected);
+    expect(responseSpy).toHaveBeenCalled();
   });
 
   it('will create a new user, specifying all parameters', async () => {
@@ -70,11 +88,16 @@ describe('createUser', () => {
           phoneNumbers: [{ id: 1, phoneNumber: request.phoneNumber }],
         },
       },
+      headers: {
+        'content-type': 'application/json',
+        'x-request-id': fakeRequestId,
+      },
     };
 
     const actual = await createUser(request, prisma);
 
     expect(actual).toStrictEqual(expected);
+    expect(responseSpy).toHaveBeenCalled();
   });
 
   it('should return a email already registered error', async () => {
@@ -88,6 +111,10 @@ describe('createUser', () => {
         code: 'emailAlreadyRegistered',
         message: `email is already registered`,
       },
+      headers: {
+        'content-type': 'application/json',
+        'x-request-id': fakeRequestId,
+      },
     };
 
     await createUser(request, prisma);
@@ -95,6 +122,7 @@ describe('createUser', () => {
     const actual = await createUser(request, prisma);
 
     expect(actual).toStrictEqual(expected);
+    expect(responseSpy).toHaveBeenCalled();
   });
 
   it('should return a validation error', async () => {
@@ -110,10 +138,15 @@ describe('createUser', () => {
           { key: 'email', reason: 'must match format "email"' },
         ],
       },
+      headers: {
+        'content-type': 'application/json',
+        'x-request-id': fakeRequestId,
+      },
     };
 
     const actual = await createUser(request, prisma);
 
     expect(actual).toStrictEqual(expected);
+    expect(responseSpy).toHaveBeenCalled();
   });
 });

--- a/src/api/v1/__tests__/hello.spec.ts
+++ b/src/api/v1/__tests__/hello.spec.ts
@@ -63,6 +63,7 @@ describe('hello', () => {
 
   it('should return a validation error', () => {
     const request = {
+      'x-request-id': 'aaaaaaaa-bbbbbbbbb-123-dddddddddddd',
       name: 'MokoCatMokoCat',
       status: 10,
     };
@@ -74,6 +75,10 @@ describe('hello', () => {
         validationErrors: [
           { key: 'name', reason: 'must NOT have more than 8 characters' },
           { key: 'status', reason: 'must be <= 1' },
+          {
+            key: 'x-request-id',
+            reason: 'must NOT have fewer than 36 characters',
+          },
         ],
       },
       headers: {

--- a/src/api/v1/__tests__/hello.spec.ts
+++ b/src/api/v1/__tests__/hello.spec.ts
@@ -1,8 +1,25 @@
 import hello, { HelloErrorResponse, HelloSuccessResponse } from '../hello';
 import { HttpStatusCode } from '@constants/httpStatusCode';
 import { validationErrorResponseMessage } from '../../response';
+import * as response from '../../response';
 
 describe('hello', () => {
+  let responseSpy;
+  const fakeRequestId = 'aaaaaaaa-bbbbbbbbb-123-ddddddddddddd';
+
+  beforeEach(() => {
+    responseSpy = jest
+      .spyOn(response, 'createDefaultResponseHeaders')
+      .mockReturnValue({
+        'content-type': 'application/json',
+        'x-request-id': fakeRequestId,
+      });
+  });
+
+  afterEach(() => {
+    responseSpy.mockRestore();
+  });
+
   it('should return a success message', () => {
     const request = {
       name: 'Moko',
@@ -13,6 +30,10 @@ describe('hello', () => {
       statusCode: HttpStatusCode.ok,
       body: {
         message: `Hello ${request.name}, welcome to the exciting Serverless world! Your Status is ${request.status}!`,
+      },
+      headers: {
+        'content-type': 'application/json',
+        'x-request-id': fakeRequestId,
       },
     };
 
@@ -30,6 +51,10 @@ describe('hello', () => {
       body: {
         code: 'notAllowedMessage',
         message: 'message is not allowed',
+      },
+      headers: {
+        'content-type': 'application/json',
+        'x-request-id': fakeRequestId,
       },
     };
 
@@ -50,6 +75,10 @@ describe('hello', () => {
           { key: 'name', reason: 'must NOT have more than 8 characters' },
           { key: 'status', reason: 'must be <= 1' },
         ],
+      },
+      headers: {
+        'content-type': 'application/json',
+        'x-request-id': fakeRequestId,
       },
     };
 

--- a/src/api/v1/__tests__/helloWithPath.spec.ts
+++ b/src/api/v1/__tests__/helloWithPath.spec.ts
@@ -64,6 +64,7 @@ describe('helloWithPath', () => {
 
   it('should return a validation error', () => {
     const request = {
+      'x-request-id': 'aaaaaaaa-bbbbbbbbb-123-dddddddddddd',
       helloId: 'MokoCatMokoCat',
     };
 
@@ -73,6 +74,10 @@ describe('helloWithPath', () => {
         message: validationErrorResponseMessage(),
         validationErrors: [
           { key: 'helloId', reason: 'must NOT have more than 8 characters' },
+          {
+            key: 'x-request-id',
+            reason: 'must NOT have fewer than 36 characters',
+          },
         ],
       },
       headers: {

--- a/src/api/v1/__tests__/helloWithPath.spec.ts
+++ b/src/api/v1/__tests__/helloWithPath.spec.ts
@@ -4,8 +4,25 @@ import helloWithPath, {
 } from '../helloWithPath';
 import { HttpStatusCode } from '@constants/httpStatusCode';
 import { validationErrorResponseMessage } from '../../response';
+import * as response from '../../response';
 
 describe('helloWithPath', () => {
+  let responseSpy;
+  const fakeRequestId = 'aaaaaaaa-bbbbbbbbb-123-ddddddddddddd';
+
+  beforeEach(() => {
+    responseSpy = jest
+      .spyOn(response, 'createDefaultResponseHeaders')
+      .mockReturnValue({
+        'content-type': 'application/json',
+        'x-request-id': fakeRequestId,
+      });
+  });
+
+  afterEach(() => {
+    responseSpy.mockRestore();
+  });
+
   it('should return a success message', () => {
     const request = {
       helloId: 'MokoCat1',
@@ -15,6 +32,10 @@ describe('helloWithPath', () => {
       statusCode: HttpStatusCode.ok,
       body: {
         message: `HelloWithPath ${request.helloId}, welcome to the exciting Serverless world!`,
+      },
+      headers: {
+        'content-type': 'application/json',
+        'x-request-id': fakeRequestId,
       },
     };
 
@@ -31,6 +52,10 @@ describe('helloWithPath', () => {
       body: {
         code: 'notAllowedHelloId',
         message: 'helloId is not allowed',
+      },
+      headers: {
+        'content-type': 'application/json',
+        'x-request-id': fakeRequestId,
       },
     };
 
@@ -49,6 +74,10 @@ describe('helloWithPath', () => {
         validationErrors: [
           { key: 'helloId', reason: 'must NOT have more than 8 characters' },
         ],
+      },
+      headers: {
+        'content-type': 'application/json',
+        'x-request-id': fakeRequestId,
       },
     };
 

--- a/src/api/v1/addressSearch.ts
+++ b/src/api/v1/addressSearch.ts
@@ -19,7 +19,7 @@ import { AddressSchema } from '../domain/types/schemas/addressSchema';
 import { DefaultApiRequest } from '../request';
 import { RequestSchema } from '../domain/types/schemas/requestSchema';
 
-type Request = DefaultApiRequest & {
+export type Request = DefaultApiRequest & {
   postalCode: string;
 };
 

--- a/src/api/v1/addressSearch.ts
+++ b/src/api/v1/addressSearch.ts
@@ -4,6 +4,7 @@ import {
   ValidationErrorResponse,
   createSuccessResponse,
   createErrorResponse,
+  createDefaultResponseHeaders,
 } from '../response';
 import { FetchAddressByPostalCode } from '../repositories/interfaces/address';
 import {
@@ -15,8 +16,9 @@ import { HttpStatusCode } from '@constants/httpStatusCode';
 import { valueOf } from '../utils/valueOf';
 import validate from '../validate';
 import { AddressSchema } from '../domain/types/schemas/addressSchema';
+import { DefaultApiRequest } from '../request';
 
-type Request = {
+type Request = DefaultApiRequest & {
   postalCode: string;
 };
 
@@ -70,6 +72,7 @@ export const addressSearch = async (
         statusCode: HttpStatusCode.badRequest,
         errorCode: 'notAllowedPostalCode',
         errorMessage: 'not allowed to search by that postalCode',
+        headers: createDefaultResponseHeaders(request['x-request-id']),
       });
     }
 
@@ -78,14 +81,16 @@ export const addressSearch = async (
     return createSuccessResponse<ResponseBody>({
       statusCode: HttpStatusCode.ok,
       body: address,
+      headers: createDefaultResponseHeaders(request['x-request-id']),
     });
   } catch (error) {
-    return createAddressSearchErrorResponse(error);
+    return createAddressSearchErrorResponse(error, request);
   }
 };
 
 const createAddressSearchErrorResponse = (
   error: FetchAddressByPostalCodeError,
+  request: Request,
 ): AddressSearchErrorResponse => {
   const errorMessage = error.message as FetchAddressByPostalCodeErrorMessage;
 
@@ -95,12 +100,14 @@ const createAddressSearchErrorResponse = (
         statusCode: HttpStatusCode.notFound,
         errorCode: 'notFoundAddress',
         errorMessage: 'address is not found',
+        headers: createDefaultResponseHeaders(request['x-request-id']),
       });
     case 'unexpectedError':
       return createErrorResponse<ErrorCode, ErrorMessage>({
         statusCode: HttpStatusCode.internalServerError,
         errorCode: 'unexpectedError',
         errorMessage: 'unexpected error',
+        headers: createDefaultResponseHeaders(request['x-request-id']),
       });
     default:
       return assertNever(errorMessage);

--- a/src/api/v1/addressSearch.ts
+++ b/src/api/v1/addressSearch.ts
@@ -17,6 +17,7 @@ import { valueOf } from '../utils/valueOf';
 import validate from '../validate';
 import { AddressSchema } from '../domain/types/schemas/addressSchema';
 import { DefaultApiRequest } from '../request';
+import { RequestSchema } from '../domain/types/schemas/requestSchema';
 
 type Request = DefaultApiRequest & {
   postalCode: string;
@@ -45,6 +46,7 @@ const schema = {
   type: 'object',
   properties: {
     postalCode: AddressSchema.postalCode,
+    'x-request-id': RequestSchema['x-request-id'],
   },
   required: ['postalCode'],
   additionalProperties: false,

--- a/src/api/v1/createUser.ts
+++ b/src/api/v1/createUser.ts
@@ -20,7 +20,7 @@ import assertNever from '../utils/assertNever';
 import { DefaultApiRequest } from '../request';
 import { RequestSchema } from '../domain/types/schemas/requestSchema';
 
-type Request = DefaultApiRequest & {
+export type Request = DefaultApiRequest & {
   email: string;
   phoneNumber?: string;
 };

--- a/src/api/v1/createUser.ts
+++ b/src/api/v1/createUser.ts
@@ -18,6 +18,7 @@ import { createNewUser } from '../repositories/implements/prisma/user';
 import { CreateNewUserErrorMessage } from '../repositories/errors/createNewUserError';
 import assertNever from '../utils/assertNever';
 import { DefaultApiRequest } from '../request';
+import { RequestSchema } from '../domain/types/schemas/requestSchema';
 
 type Request = DefaultApiRequest & {
   email: string;
@@ -45,6 +46,7 @@ const schema = {
   properties: {
     email: UserSchema.email,
     phoneNumber: UserSchema.phoneNumber,
+    'x-request-id': RequestSchema['x-request-id'],
   },
   required: ['email'],
   additionalProperties: false,

--- a/src/api/v1/createUser.ts
+++ b/src/api/v1/createUser.ts
@@ -6,6 +6,7 @@ import {
   ValidationErrorResponse,
   createSuccessResponse,
   createErrorResponse,
+  createDefaultResponseHeaders,
 } from '../response';
 
 import { UserEntity } from '../domain/types/userEntity';
@@ -16,8 +17,9 @@ import { UserSchema } from '../domain/types/schemas/userSchema';
 import { createNewUser } from '../repositories/implements/prisma/user';
 import { CreateNewUserErrorMessage } from '../repositories/errors/createNewUserError';
 import assertNever from '../utils/assertNever';
+import { DefaultApiRequest } from '../request';
 
-type Request = {
+type Request = DefaultApiRequest & {
   email: string;
   phoneNumber?: string;
 };
@@ -77,12 +79,14 @@ export const createUser = async (
             statusCode: HttpStatusCode.badRequest,
             errorCode: 'emailAlreadyRegistered',
             errorMessage: 'email is already registered',
+            headers: createDefaultResponseHeaders(request['x-request-id']),
           });
         case 'unexpectedError':
           return createErrorResponse<ErrorCode, ErrorMessage>({
             statusCode: HttpStatusCode.internalServerError,
             errorCode: 'dbError',
             errorMessage: 'error in database',
+            headers: createDefaultResponseHeaders(request['x-request-id']),
           });
         default:
           assertNever(errorMessage);
@@ -92,12 +96,14 @@ export const createUser = async (
     return createSuccessResponse<ResponseBody>({
       statusCode: HttpStatusCode.created,
       body: { user: createNewUserResponse.userEntity },
+      headers: createDefaultResponseHeaders(request['x-request-id']),
     });
   } catch (error) {
     return createErrorResponse<ErrorCode, ErrorMessage>({
       statusCode: HttpStatusCode.internalServerError,
       errorCode: 'dbError',
       errorMessage: 'error in database',
+      headers: createDefaultResponseHeaders(request['x-request-id']),
     });
   } finally {
     await prisma.$disconnect();

--- a/src/api/v1/hello.ts
+++ b/src/api/v1/hello.ts
@@ -11,6 +11,7 @@ import { valueOf } from '../utils/valueOf';
 import validate from '../validate';
 import { HelloSchema } from '../domain/types/schemas/helloSchema';
 import { DefaultApiRequest } from '../request';
+import { RequestSchema } from '../domain/types/schemas/requestSchema';
 
 type Request = DefaultApiRequest & {
   name: string;
@@ -37,6 +38,7 @@ const schema = {
   properties: {
     name: HelloSchema.name,
     status: HelloSchema.status,
+    'x-request-id': RequestSchema['x-request-id'],
   },
   required: ['name', 'status'],
   additionalProperties: false,

--- a/src/api/v1/hello.ts
+++ b/src/api/v1/hello.ts
@@ -13,7 +13,7 @@ import { HelloSchema } from '../domain/types/schemas/helloSchema';
 import { DefaultApiRequest } from '../request';
 import { RequestSchema } from '../domain/types/schemas/requestSchema';
 
-type Request = DefaultApiRequest & {
+export type Request = DefaultApiRequest & {
   name: string;
   status: number;
 };

--- a/src/api/v1/hello.ts
+++ b/src/api/v1/hello.ts
@@ -4,13 +4,15 @@ import {
   ValidationErrorResponse,
   createSuccessResponse,
   createErrorResponse,
+  createDefaultResponseHeaders,
 } from '../response';
 import { HttpStatusCode } from '@constants/httpStatusCode';
 import { valueOf } from '../utils/valueOf';
 import validate from '../validate';
 import { HelloSchema } from '../domain/types/schemas/helloSchema';
+import { DefaultApiRequest } from '../request';
 
-type Request = {
+type Request = DefaultApiRequest & {
   name: string;
   status: number;
 };
@@ -56,6 +58,7 @@ export const hello = (
       statusCode: HttpStatusCode.badRequest,
       errorCode: 'notAllowedMessage',
       errorMessage: 'message is not allowed',
+      headers: createDefaultResponseHeaders(request['x-request-id']),
     });
   }
 
@@ -64,6 +67,7 @@ export const hello = (
     body: {
       message: `Hello ${request.name}, welcome to the exciting Serverless world! Your Status is ${request.status}!`,
     },
+    headers: createDefaultResponseHeaders(request['x-request-id']),
   });
 };
 

--- a/src/api/v1/helloWithPath.ts
+++ b/src/api/v1/helloWithPath.ts
@@ -13,7 +13,7 @@ import { HelloSchema } from '../domain/types/schemas/helloSchema';
 import { DefaultApiRequest } from '../request';
 import { RequestSchema } from '../domain/types/schemas/requestSchema';
 
-type Request = DefaultApiRequest & {
+export type Request = DefaultApiRequest & {
   helloId: string;
 };
 

--- a/src/api/v1/helloWithPath.ts
+++ b/src/api/v1/helloWithPath.ts
@@ -11,6 +11,7 @@ import { valueOf } from '../utils/valueOf';
 import validate from '../validate';
 import { HelloSchema } from '../domain/types/schemas/helloSchema';
 import { DefaultApiRequest } from '../request';
+import { RequestSchema } from '../domain/types/schemas/requestSchema';
 
 type Request = DefaultApiRequest & {
   helloId: string;
@@ -35,6 +36,7 @@ const schema = {
   type: 'object',
   properties: {
     helloId: HelloSchema.helloId,
+    'x-request-id': RequestSchema['x-request-id'],
   },
   required: ['helloId'],
   additionalProperties: false,

--- a/src/api/v1/helloWithPath.ts
+++ b/src/api/v1/helloWithPath.ts
@@ -4,13 +4,15 @@ import {
   ValidationErrorResponse,
   createSuccessResponse,
   createErrorResponse,
+  createDefaultResponseHeaders,
 } from '../response';
 import { HttpStatusCode } from '@constants/httpStatusCode';
 import { valueOf } from '../utils/valueOf';
 import validate from '../validate';
 import { HelloSchema } from '../domain/types/schemas/helloSchema';
+import { DefaultApiRequest } from '../request';
 
-type Request = {
+type Request = DefaultApiRequest & {
   helloId: string;
 };
 
@@ -57,6 +59,7 @@ export const helloWithPath = (
       statusCode: HttpStatusCode.badRequest,
       errorCode: 'notAllowedHelloId',
       errorMessage: 'helloId is not allowed',
+      headers: createDefaultResponseHeaders(request['x-request-id']),
     });
   }
 
@@ -65,6 +68,7 @@ export const helloWithPath = (
     body: {
       message: `HelloWithPath ${request.helloId}, welcome to the exciting Serverless world!`,
     },
+    headers: createDefaultResponseHeaders(request['x-request-id']),
   });
 };
 

--- a/src/api/validate.ts
+++ b/src/api/validate.ts
@@ -3,7 +3,6 @@ import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import {
   createDefaultResponseHeaders,
-  ResponseHeaders,
   ValidationErrorResponse,
   validationErrorResponseMessage,
 } from './response';
@@ -14,11 +13,7 @@ type ValidateResult = {
   validationErrorResponse?: ValidationErrorResponse;
 };
 
-const validate = <T>(
-  schema: Schema,
-  params: T,
-  responseHeaders: ResponseHeaders = createDefaultResponseHeaders(),
-): ValidateResult => {
+const validate = <T>(schema: Schema, params: T): ValidateResult => {
   const ajv = new Ajv({ allErrors: true });
   addFormats(ajv);
 
@@ -31,6 +26,13 @@ const validate = <T>(
         reason: value.message,
       };
     });
+
+    const responseHeaders = Object.prototype.hasOwnProperty.call(
+      params,
+      'x-request-id',
+    )
+      ? createDefaultResponseHeaders(params['x-request-id'])
+      : createDefaultResponseHeaders();
 
     const validationErrorResponse = {
       statusCode: HttpStatusCode.unprocessableEntity,

--- a/src/api/validate.ts
+++ b/src/api/validate.ts
@@ -2,6 +2,8 @@ import { Schema } from 'ajv/lib/types/index';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import {
+  createDefaultResponseHeaders,
+  ResponseHeaders,
   ValidationErrorResponse,
   validationErrorResponseMessage,
 } from './response';
@@ -12,7 +14,11 @@ type ValidateResult = {
   validationErrorResponse?: ValidationErrorResponse;
 };
 
-const validate = <T>(schema: Schema, params: T): ValidateResult => {
+const validate = <T>(
+  schema: Schema,
+  params: T,
+  responseHeaders: ResponseHeaders = createDefaultResponseHeaders(),
+): ValidateResult => {
   const ajv = new Ajv({ allErrors: true });
   addFormats(ajv);
 
@@ -32,6 +38,7 @@ const validate = <T>(schema: Schema, params: T): ValidateResult => {
         message: validationErrorResponseMessage(),
         validationErrors,
       },
+      headers: responseHeaders,
     };
 
     return { isError: true, validationErrorResponse };

--- a/src/constants/defaultRequestHeader.ts
+++ b/src/constants/defaultRequestHeader.ts
@@ -2,6 +2,7 @@ export default {
   type: 'object',
   properties: {
     'content-type': { type: 'string' },
+    'x-request-id': { type: 'string' },
   },
   required: ['content-type'],
 } as const;

--- a/src/functions/addressSearch/handler.ts
+++ b/src/functions/addressSearch/handler.ts
@@ -23,7 +23,11 @@ const addressSearchHandler: ValidatedEventAPIGatewayProxyEvent<
 
   const response = await addressSearch(request, fetchAddressByPostalCode);
 
-  return formatJsonResponse(response.statusCode, response.body);
+  return formatJsonResponse(
+    response.statusCode,
+    response.body,
+    response.headers,
+  );
 };
 
 export const main = middyfy(addressSearchHandler);

--- a/src/functions/addressSearch/handler.ts
+++ b/src/functions/addressSearch/handler.ts
@@ -19,7 +19,15 @@ const addressSearchHandler: ValidatedEventAPIGatewayProxyEvent<
   typeof pathParams,
   typeof defaultQueryParams
 > = async (event) => {
-  const request = event.pathParameters;
+  const request = Object.prototype.hasOwnProperty.call(
+    event.headers,
+    'x-request-id',
+  )
+    ? {
+        ...event.pathParameters,
+        ...{ 'x-request-id': event.headers['x-request-id'] },
+      }
+    : { ...event.pathParameters };
 
   const response = await addressSearch(request, fetchAddressByPostalCode);
 

--- a/src/functions/addressSearch/handler.ts
+++ b/src/functions/addressSearch/handler.ts
@@ -11,7 +11,8 @@ import defaultQueryParams from '@constants/defaultQueryParams';
 import pathParams from './pathParams';
 
 import { fetchAddressByPostalCode } from '../../api/repositories/implements/axios/address';
-import addressSearch from '../../api/v1/addressSearch';
+import addressSearch, { Request } from '../../api/v1/addressSearch';
+import { createApiRequest } from '../../api/request';
 
 const addressSearchHandler: ValidatedEventAPIGatewayProxyEvent<
   typeof defaultRequestHeader,
@@ -19,15 +20,10 @@ const addressSearchHandler: ValidatedEventAPIGatewayProxyEvent<
   typeof pathParams,
   typeof defaultQueryParams
 > = async (event) => {
-  const request = Object.prototype.hasOwnProperty.call(
+  const request = createApiRequest<Request>(
     event.headers,
-    'x-request-id',
-  )
-    ? {
-        ...event.pathParameters,
-        ...{ 'x-request-id': event.headers['x-request-id'] },
-      }
-    : { ...event.pathParameters };
+    event.pathParameters,
+  );
 
   const response = await addressSearch(request, fetchAddressByPostalCode);
 

--- a/src/functions/createUser/handler.ts
+++ b/src/functions/createUser/handler.ts
@@ -12,7 +12,8 @@ import defaultPathParams from '@constants/defaultPathParams';
 import defaultQueryParams from '@constants/defaultQueryParams';
 
 import requestBody from './requestBody';
-import createUser from '../../api/v1/createUser';
+import createUser, { Request } from '../../api/v1/createUser';
+import { createApiRequest } from '../../api/request';
 
 const prisma = new PrismaClient({ log: ['query', 'info', `warn`, `error`] });
 
@@ -22,12 +23,7 @@ const createUserHandler: ValidatedEventAPIGatewayProxyEvent<
   typeof defaultPathParams,
   typeof defaultQueryParams
 > = async (event) => {
-  const request = Object.prototype.hasOwnProperty.call(
-    event.headers,
-    'x-request-id',
-  )
-    ? { ...event.body, ...{ 'x-request-id': event.headers['x-request-id'] } }
-    : { ...event.body };
+  const request = createApiRequest<Request>(event.headers, event.body);
 
   const response = await createUser(request, prisma);
 

--- a/src/functions/createUser/handler.ts
+++ b/src/functions/createUser/handler.ts
@@ -22,7 +22,12 @@ const createUserHandler: ValidatedEventAPIGatewayProxyEvent<
   typeof defaultPathParams,
   typeof defaultQueryParams
 > = async (event) => {
-  const request = event.body;
+  const request = Object.prototype.hasOwnProperty.call(
+    event.headers,
+    'x-request-id',
+  )
+    ? { ...event.body, ...{ 'x-request-id': event.headers['x-request-id'] } }
+    : { ...event.body };
 
   const response = await createUser(request, prisma);
 

--- a/src/functions/createUser/handler.ts
+++ b/src/functions/createUser/handler.ts
@@ -26,7 +26,11 @@ const createUserHandler: ValidatedEventAPIGatewayProxyEvent<
 
   const response = await createUser(request, prisma);
 
-  return formatJsonResponse(response.statusCode, response.body);
+  return formatJsonResponse(
+    response.statusCode,
+    response.body,
+    response.headers,
+  );
 };
 
 export const main = middyfy(createUserHandler);

--- a/src/functions/hello/handler.ts
+++ b/src/functions/hello/handler.ts
@@ -20,7 +20,11 @@ const helloHandler: ValidatedEventAPIGatewayProxyEvent<
 
   const response = hello(request);
 
-  return formatJsonResponse(response.statusCode, response.body);
+  return formatJsonResponse(
+    response.statusCode,
+    response.body,
+    response.headers,
+  );
 };
 
 export const main = middyfy(helloHandler);

--- a/src/functions/hello/handler.ts
+++ b/src/functions/hello/handler.ts
@@ -8,7 +8,8 @@ import defaultQueryParams from '@constants/defaultQueryParams';
 
 import requestHeader from './requestHeader';
 import requestBody from './requestBody';
-import hello from '../../api/v1/hello';
+import hello, { Request } from '../../api/v1/hello';
+import { createApiRequest } from '../../api/request';
 
 const helloHandler: ValidatedEventAPIGatewayProxyEvent<
   typeof requestHeader,
@@ -16,12 +17,7 @@ const helloHandler: ValidatedEventAPIGatewayProxyEvent<
   typeof defaultPathParams,
   typeof defaultQueryParams
 > = async (event) => {
-  const request = Object.prototype.hasOwnProperty.call(
-    event.headers,
-    'x-request-id',
-  )
-    ? { ...event.body, ...{ 'x-request-id': event.headers['x-request-id'] } }
-    : { ...event.body };
+  const request = createApiRequest<Request>(event.headers, event.body);
 
   const response = hello(request);
 

--- a/src/functions/hello/handler.ts
+++ b/src/functions/hello/handler.ts
@@ -16,7 +16,12 @@ const helloHandler: ValidatedEventAPIGatewayProxyEvent<
   typeof defaultPathParams,
   typeof defaultQueryParams
 > = async (event) => {
-  const request = event.body;
+  const request = Object.prototype.hasOwnProperty.call(
+    event.headers,
+    'x-request-id',
+  )
+    ? { ...event.body, ...{ 'x-request-id': event.headers['x-request-id'] } }
+    : { ...event.body };
 
   const response = hello(request);
 

--- a/src/functions/hello/requestHeader.ts
+++ b/src/functions/hello/requestHeader.ts
@@ -1,7 +1,10 @@
+import { RequestSchema } from '../../api/domain/types/schemas/requestSchema';
+
 export default {
   type: 'object',
   properties: {
     authorization: { type: 'string' },
+    'x-request-id': RequestSchema['x-request-id'],
   },
   required: ['authorization'],
 } as const;

--- a/src/functions/hello/requestHeader.ts
+++ b/src/functions/hello/requestHeader.ts
@@ -4,6 +4,7 @@ export default {
   type: 'object',
   properties: {
     authorization: { type: 'string' },
+    'content-type': { type: 'string' },
     'x-request-id': RequestSchema['x-request-id'],
   },
   required: ['authorization'],

--- a/src/functions/helloWithPath/handler.ts
+++ b/src/functions/helloWithPath/handler.ts
@@ -17,7 +17,15 @@ const helloWithPathHandler: ValidatedEventAPIGatewayProxyEvent<
   typeof pathParams,
   typeof queryParams
 > = async (event) => {
-  const request = event.pathParameters;
+  const request = Object.prototype.hasOwnProperty.call(
+    event.headers,
+    'x-request-id',
+  )
+    ? {
+        ...event.pathParameters,
+        ...{ 'x-request-id': event.headers['x-request-id'] },
+      }
+    : { ...event.pathParameters };
 
   const response = helloWithPath(request);
 

--- a/src/functions/helloWithPath/handler.ts
+++ b/src/functions/helloWithPath/handler.ts
@@ -21,7 +21,11 @@ const helloWithPathHandler: ValidatedEventAPIGatewayProxyEvent<
 
   const response = helloWithPath(request);
 
-  return formatJsonResponse(response.statusCode, response.body);
+  return formatJsonResponse(
+    response.statusCode,
+    response.body,
+    response.headers,
+  );
 };
 
 export const main = middyfy(helloWithPathHandler);

--- a/src/functions/helloWithPath/handler.ts
+++ b/src/functions/helloWithPath/handler.ts
@@ -9,7 +9,8 @@ import defaultRequestBody from '@constants/defaultRequestBody';
 
 import pathParams from './pathParams';
 import queryParams from './queryParams';
-import helloWithPath from '../../api/v1/helloWithPath';
+import helloWithPath, { Request } from '../../api/v1/helloWithPath';
+import { createApiRequest } from '../../api/request';
 
 const helloWithPathHandler: ValidatedEventAPIGatewayProxyEvent<
   typeof defaultRequestHeader,
@@ -17,15 +18,10 @@ const helloWithPathHandler: ValidatedEventAPIGatewayProxyEvent<
   typeof pathParams,
   typeof queryParams
 > = async (event) => {
-  const request = Object.prototype.hasOwnProperty.call(
+  const request = createApiRequest<Request>(
     event.headers,
-    'x-request-id',
-  )
-    ? {
-        ...event.pathParameters,
-        ...{ 'x-request-id': event.headers['x-request-id'] },
-      }
-    : { ...event.pathParameters };
+    event.pathParameters,
+  );
 
   const response = helloWithPath(request);
 

--- a/src/libs/apiGateway.ts
+++ b/src/libs/apiGateway.ts
@@ -5,6 +5,7 @@ import type {
 } from 'aws-lambda';
 import type { FromSchema } from 'json-schema-to-ts';
 import { HttpStatusCode } from '@constants/httpStatusCode';
+import { ResponseHeaders } from '../api/responseHeaders';
 
 type ValidatedAPIGatewayProxyEvent<S, T, U, V> = Omit<
   APIGatewayProxyEventV2,
@@ -20,9 +21,11 @@ export type ValidatedEventAPIGatewayProxyEvent<S, T, U, V> = Handler<
 export const formatJsonResponse = (
   statusCode: HttpStatusCode,
   responseBody: Record<string, unknown>,
-): { statusCode: HttpStatusCode; body: string } => {
+  responseHeaders: ResponseHeaders,
+): { statusCode: HttpStatusCode; body: string; headers: ResponseHeaders } => {
   return {
     statusCode: statusCode,
     body: JSON.stringify(responseBody),
+    headers: responseHeaders,
   };
 };

--- a/src/libs/apiGateway.ts
+++ b/src/libs/apiGateway.ts
@@ -5,7 +5,7 @@ import type {
 } from 'aws-lambda';
 import type { FromSchema } from 'json-schema-to-ts';
 import { HttpStatusCode } from '@constants/httpStatusCode';
-import { ResponseHeaders } from '../api/responseHeaders';
+import { ResponseHeaders } from '../api/response';
 
 type ValidatedAPIGatewayProxyEvent<S, T, U, V> = Omit<
   APIGatewayProxyEventV2,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1179,6 +1179,11 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.0.tgz#fef1904e4668b6e5ecee60c52cc6a078ffa6697d"
   integrity sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
 
+"@types/uuid@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
+
 "@types/yargs-parser@*":
   version "20.2.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.0.tgz#dd3e6699ba3237f0348cd085e4698780204842f9"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/aws-serverless-node-api-boilerplate/issues/38

# Doneの定義
- https://github.com/nekochans/aws-serverless-node-api-boilerplate/issues/38 の完了の定義を満たしている事

# 変更点概要

レスポンス生成時に任意のHTTPヘッダーを返せるように変更しました。

APIのログを検索しやすいようにレスポンスヘッダーに `x-request-id` を追加してあります。

ちなみにリクエストヘッダーに `x-request-id` があった場合はその値をそのまま返すようにしてあります。

これは他のAPIからこのAPIが呼ばれた際にログを横断的に検索出来るようにする事が目的です。

```
curl -X GET -kv \
-H "Authorization: Bearer YOUR ACCESS TOKEN" \
-H "X-Request-Id: aaaaaaaa-bbbbbbbbb-123-ddddddddddddd" \
https://xxxxxxxxxx.execute-api.ap-northeast-1.amazonaws.com/hello/mokomoko | jq
```

```
< HTTP/2 200
< date: Tue, 29 Jun 2021 08:23:39 GMT
< content-type: application/json
< content-length: 79
< x-request-id: aaaaaaaa-bbbbbbbbb-123-ddddddddddddd
```