### PR TITLE
prisma:introspectをローカルで使用する前提に変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "run-s lint:*",
     "format": "run-s fix:*",
     "test": "DATABASE_URL=\"mysql://serverless_test_user:Serverless_Test_User|8888@127.0.0.1:63306/serverless_test\" jest",
-    "prisma:introspect": "prisma introspect --force",
+    "prisma:introspect": "DATABASE_URL=\"mysql://serverless_test_user:Serverless_Test_User|8888@127.0.0.1:63306/serverless_test\" prisma introspect --force",
     "prisma:generate": "prisma generate"
   },
   "engines": {


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/aws-serverless-node-api-boilerplate/issues/39

# Done の定義

prisma:introspectをローカルで使用する前提する形に変更

# 変更点概要

`prisma:introspect` のDATABASE_URLが常にテスト環境を指すように修正。

基本的にローカル以外でこのコマンドを実行する必要がないので、このように変更した。

# 補足情報
もともと、https://github.com/nekochans/aws-serverless-node-api-boilerplate/issues/39 を解決する予定だったが、以下のようにカスタマイズの運用はそれなりに難しいので、やはり今のシンプルなMigrationの仕組みを利用するようにした。

https://www.prisma.io/docs/concepts/components/prisma-migrate#customizing-migrations